### PR TITLE
[REM-24598][iOS] [Perf] Use AppID instead of package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You must specify the following values in your application's info.plist in order 
 | `RPTSubscriptionKey` | Only internal Rakuten developers can setup a key. If not a Rakuten developer set a non-empty string |
 | `RPTConfigAPIEndpoint` | Endpoint to fetch the module configuration - see `_RPTConfiguration` class for response format |
 | `RPTLocationAPIEndpoint` | Endpoint to fetch the current location - see `_RPTLocation` class for response format |
+| `RPTRelayAppID` | Relay portal application ID. Only internal Rakuten developers can setup app ID. If not a Rakuten developer set a non-empty string |
 
 Now your application is ready to automatically track the `Launch` metric, network requests, view lifecycle methods, and more.
 

--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -160,12 +160,18 @@ RPT_EXPORT @interface _RPTTrackingKey : NSObject<NSCopying>
     NSString *thisVersion   = [thisBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     
     NSBundle *appBundle     = NSBundle.mainBundle;
-    NSString *appIdentifier = appBundle.bundleIdentifier;
+    NSString *relayAppID    = [appBundle objectForInfoDictionaryKey:@"RPTRelayAppID"];
     NSString *appVersion    = [appBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     
     NSString *country       = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
     
-    NSString *path = [NSString stringWithFormat:@"/platform/ios/app/%@/version/%@/", appIdentifier, appVersion];
+    NSString *path = [NSString stringWithFormat:@"/platform/ios/"];
+    if (relayAppID.length){ path = [path stringByAppendingString:[NSString stringWithFormat:@"app/%@/", relayAppID]]; }
+#if DEBUG
+    NSAssert(relayAppID.length, @"Your application's Info.plist must contain a key 'RPTRelayAppID' set to the relay Portal application ID");
+#endif
+    
+    path = [path stringByAppendingString:[NSString stringWithFormat:@"version/%@/", appVersion]];
     
     NSURLSessionConfiguration *sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration;
     

--- a/Tests/HostApp/Info.plist
+++ b/Tests/HostApp/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>RPTLocationAPIEndpoint</key>
 	<string>https://location-endpoint.com</string>
+	<key>RPTRelayAppID</key>
+	<string>RELAYAPP_ID</string>
 	<key>RPTSubscriptionKey</key>
 	<string>SUBSCRIPTION_KEY</string>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Updated the ReadMe and fetch value from info.plist for new relay portal app ID.