### PR TITLE
[REM-25013][iOS] [Perf] Include AppID in payload sent to event hub

### DIFF
--- a/RPerformanceTracking/Private/_RPTEventWriter.m
+++ b/RPerformanceTracking/Private/_RPTEventWriter.m
@@ -73,6 +73,7 @@ NSString *_RPTJSONFormatWithFloatValue(NSString *key, float value)
     static NSString *modelIdentifier;
     static UIDevice *device;
     static NSString *osVersion;
+    static NSString *relayAppID;
     __block NSString *carrierName;
     static SCNetworkReachabilityRef reachability;
 
@@ -83,6 +84,7 @@ NSString *_RPTJSONFormatWithFloatValue(NSString *key, float value)
         appVersion = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         device = UIDevice.currentDevice;
         osVersion = [NSString stringWithFormat:@"%@", device.systemVersion];
+        relayAppID = [bundle objectForInfoDictionaryKey:@"RPTRelayAppID"];
 
         struct utsname systemInfo;
         uname(&systemInfo);
@@ -137,7 +139,13 @@ NSString *_RPTJSONFormatWithFloatValue(NSString *key, float value)
     {
         [_writer appendString:_RPTJSONFormatWithStringValue(@"app", appIdentifier)];
     }
-
+    
+    if (relayAppID)
+    {
+        [_writer appendString:@","];
+        [_writer appendString:_RPTJSONFormatWithStringValue(@"relay_app_id", relayAppID)];
+    }
+    
     if (appVersion)
     {
         [_writer appendString:@","];

--- a/Tests/EventWriterTests.m
+++ b/Tests/EventWriterTests.m
@@ -42,7 +42,7 @@
     OCMStub([mockDevice usedAppMemory]).andReturn(100);
     OCMStub([mockDevice batteryLevel]).andReturn(0.86f);
 
-    _fixedPrefix = [NSString stringWithFormat:@"{\"app\":\"%@\",\"version\":\"1.0\",\"device\":\"x86_64\",\"country\":\"US\",\"network\":\"wifi\",\"os\":\"ios\",\"os_version\":\"%@\",\"app_mem_used\":100,\"device_mem_free\":3000,\"device_mem_total\":10000,\"battery_level\":0.86,\"measurements\":[", NSBundle.mainBundle.bundleIdentifier, UIDevice.currentDevice.systemVersion];
+    _fixedPrefix = [NSString stringWithFormat:@"{\"app\":\"%@\",\"relay_app_id\":\"%@\",\"version\":\"1.0\",\"device\":\"x86_64\",\"country\":\"US\",\"network\":\"wifi\",\"os\":\"ios\",\"os_version\":\"%@\",\"app_mem_used\":100,\"device_mem_free\":3000,\"device_mem_total\":10000,\"battery_level\":0.86,\"measurements\":[", NSBundle.mainBundle.bundleIdentifier, [NSBundle.mainBundle objectForInfoDictionaryKey:@"RPTRelayAppID"], UIDevice.currentDevice.systemVersion];
     
     // Ensure locale is used
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
@@ -189,7 +189,7 @@
     [eventWriter writeWithMetric:[self defaultMetric]];
     XCTAssertNotNil(eventWriter.writer);
     
-    NSString *prefix = [NSString stringWithFormat:@"{\"app\":\"%@\",\"version\":\"1.0\",\"device\":\"x86_64\",\"country\":\"%@\",\"network\":\"wifi\",\"os\":\"ios\",\"os_version\":\"%@\",\"app_mem_used\":100,\"device_mem_free\":3000,\"device_mem_total\":10000,\"battery_level\":0.86,\"measurements\":[", NSBundle.mainBundle.bundleIdentifier, [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode], UIDevice.currentDevice.systemVersion];
+    NSString *prefix = [NSString stringWithFormat:@"{\"app\":\"%@\",\"relay_app_id\":\"%@\",\"version\":\"1.0\",\"device\":\"x86_64\",\"country\":\"%@\",\"network\":\"wifi\",\"os\":\"ios\",\"os_version\":\"%@\",\"app_mem_used\":100,\"device_mem_free\":3000,\"device_mem_total\":10000,\"battery_level\":0.86,\"measurements\":[", NSBundle.mainBundle.bundleIdentifier, [NSBundle.mainBundle objectForInfoDictionaryKey:@"RPTRelayAppID"], [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode], UIDevice.currentDevice.systemVersion];
     
     NSString *responseString = [NSString stringWithFormat:@"%@{\"metric\":\"default_metric\",\"urls\":5,\"time\":3000,\"start\":1200}", prefix];
     XCTAssertEqualObjects(eventWriter.writer.copy, responseString);


### PR DESCRIPTION
Added Relay APPID as a payload sent to event hub.
Updated uni test cases.