### PR TITLE
REM-25817 Fix crash that occurs when info.plist keys are missing

### DIFF
--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -201,6 +201,12 @@ RPT_EXPORT @interface _RPTTrackingKey : NSObject<NSCopying>
     
     NSURL *url = [base URLByAppendingPathComponent:path];
     
+    if (!url || !baseURLString.length || !subscriptionKey.length || !relayAppID.length)
+    {
+        // Fail safely in a release build if the info.plist doesn't have the expected key-values
+        return;
+    }
+    
     NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
     components.query = [NSString stringWithFormat:@"sdk=%@&country=%@", thisVersion, country];
     
@@ -276,6 +282,8 @@ RPT_EXPORT @interface _RPTTrackingKey : NSObject<NSCopying>
 #if DEBUG
     NSAssert(locationURL, @"Your application's Info.plist must contain a key 'RPTLocationAPIEndpoint' set to the endpoint URL of your Location API");
 #endif
+    
+    if (!locationURL) return;
 	
 	if (subscriptionKey) { sessionConfiguration.HTTPAdditionalHeaders = @{@"Ocp-Apim-Subscription-Key":subscriptionKey}; }
 	


### PR DESCRIPTION
Fix crash that occurs when info.plist keys are missing by failing safely in release builds