### PR TITLE
REM-25242 Fix redirect handling in custom protocol

### DIFF
--- a/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
@@ -7,6 +7,12 @@
 
 + (void)load
 {
+    if(![_RPTTrackingManager sharedInstance].disableProtocolWebviewObserving)
+    {
+        [NSURLProtocol registerClass:[_RPTNSURLProtocol class]];
+        return;
+    }
+    
     [_RPTClassManipulator addMethodFromClass:UIWebView.class
                                 withSelector:@selector(_rpt_webViewLoadRequest:)
                                      toClass:UIWebView.class
@@ -45,11 +51,6 @@
                                          toClass:recipient
                                        replacing:@selector(webView:didFailLoadWithError:)
                                    onlyIfPresent:NO];
-
-    if(![_RPTTrackingManager sharedInstance].disableProtocolWebviewObserving)
-    {
-        [NSURLProtocol registerClass:[_RPTNSURLProtocol class]];
-    }
 }
 
 @end

--- a/Tests/HostApp/Info.plist
+++ b/Tests/HostApp/Info.plist
@@ -30,6 +30,8 @@
 	<string>RELAYAPP_ID</string>
 	<key>RPTSubscriptionKey</key>
 	<string>SUBSCRIPTION_KEY</string>
+	<key>RPTDisableProtocolWebviewObserving</key>
+	<false/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
- inform the protocol client when there is a valid redirect request
- remove tracking of the session data task from the custom protocol because it is already tracked in the swizzle method _rpt_setState:
- either use UIWebView swizzling or the custom protocol to track UIWebView requests, not both

Verified in iOS 11 simulator by confirming that PointClub bugs are fixed.