### PR TITLE
REM-25345 Add tests for implementationWithBlock swizzling

### DIFF
--- a/RPerformanceTracking.xcodeproj/project.pbxproj
+++ b/RPerformanceTracking.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6D64251D1EB8611C00755DA3 /* ConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D64251C1EB8611C00755DA3 /* ConfigTests.m */; };
 		6DA30F6B1FAAF501006A4DE6 /* MainThreadWatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */; };
 		6DA949E31E94E09600856C95 /* SenderIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DA949E21E94E09600856C95 /* SenderIntegrationTests.m */; };
+		6DDD80CB1FF22BC7002DED2E /* SwizzleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */; };
 		C80E064C1EA876FF00FD22D2 /* TrackingManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C80E064B1EA876FF00FD22D2 /* TrackingManagerTests.m */; };
 		C83BA7A01EDEA2150048D5C5 /* UITableViewCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C83BA79F1EDEA2150048D5C5 /* UITableViewCellTests.m */; };
 		C85DC3EA1EA084B800F79E52 /* RingBufferTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C85DC3E91EA084B800F79E52 /* RingBufferTests.m */; };
@@ -71,6 +72,7 @@
 		6D64251C1EB8611C00755DA3 /* ConfigTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConfigTests.m; sourceTree = "<group>"; };
 		6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainThreadWatcherTests.m; sourceTree = "<group>"; };
 		6DA949E21E94E09600856C95 /* SenderIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenderIntegrationTests.m; sourceTree = "<group>"; };
+		6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwizzleTests.m; sourceTree = "<group>"; };
 		C80E064B1EA876FF00FD22D2 /* TrackingManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TrackingManagerTests.m; sourceTree = "<group>"; };
 		C83BA79F1EDEA2150048D5C5 /* UITableViewCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UITableViewCellTests.m; sourceTree = "<group>"; };
 		C85DC3E91EA084B800F79E52 /* RingBufferTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RingBufferTests.m; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				C8D982DE1F18D83C0088EBEC /* LocationTests.m */,
 				6D64251C1EB8611C00755DA3 /* ConfigTests.m */,
 				6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */,
+				6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 				C8D893921EBAF8AE001A6CEC /* WKWebViewHookTests.m in Sources */,
 				5A91BD641EB096210048689C /* UICollectionViewTests.m in Sources */,
 				C8B86DF71EC1749A00C7B8DD /* UIWebViewHookTests.m in Sources */,
+				6DDD80CB1FF22BC7002DED2E /* SwizzleTests.m in Sources */,
 				5AC8DD3C1E95E3B80067995E /* UIViewControllerTests.m in Sources */,
 				5AC8DDC81E96354D0067995E /* TestViewController.m in Sources */,
 				6DA30F6B1FAAF501006A4DE6 /* MainThreadWatcherTests.m in Sources */,

--- a/RPerformanceTracking/Private/UIControl+RPerformanceTracking.m
+++ b/RPerformanceTracking/Private/UIControl+RPerformanceTracking.m
@@ -12,7 +12,7 @@
     // UIControlEvents enum constant UIControlEventPrimaryActionTriggered was introduced in
     // iOS 9.0 but there is no way to check enum availability at runtime. Instead check that
     // UIStackView (also introduced in iOS 9.0) is available
-    BOOL primaryActionTriggeredAvailable = [UIStackView class];
+    BOOL primaryActionTriggeredAvailable = NSClassFromString(@"UIStackView");
     
     return ([[self actionsForTarget:target forControlEvent:UIControlEventTouchUpInside] containsObject:actionName] ||
             (primaryActionTriggeredAvailable && [[self actionsForTarget:target forControlEvent:UIControlEventPrimaryActionTriggered] containsObject:actionName]) ||

--- a/RPerformanceTracking/Private/_RPTClassManipulator+WKWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+WKWebView.m
@@ -52,13 +52,13 @@ static void endTrackingWithWKWebView(WKWebView *webView)
     /* The block params below are `self` and then the parameters of the swizzled method.
      * Unlike Obj-C method calls a _cmd selector is not passed to a block.
      */
-    id loadRequest_swizzle_blockImp = ^id (id selfRef, NSURLRequest *request) {
+    id loadRequest_swizzle_blockImp = ^id (id<NSObject> selfRef, NSURLRequest *request) {
         RPTLog(@"loadRequest_swizzle_blockImp called");
         
         if (request.URL) { [[_RPTTrackingManager sharedInstance].tracker prolongMetric]; }
         
         SEL selector = @selector(loadRequest:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         
         if (originalImp)
         {
@@ -89,11 +89,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
                     types:methodTypes];
     
     //  MARK: WKWebView setNavigationDelegate:
-    id setNavDelegate_swizzle_blockImp = ^void (id selfRef, id<WKNavigationDelegate> delegate) {
+    id setNavDelegate_swizzle_blockImp = ^void (id<NSObject> selfRef, id<WKNavigationDelegate> delegate) {
         RPTLog(@"setNavDelegate_swizzle_blockImp called");
         
         SEL selector = @selector(setNavigationDelegate:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             if (delegate)
@@ -118,11 +118,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
     Class recipient = delegate.class;
     
     // MARK: WKNavigationDelegate webView:didStartProvisionalNavigation:
-    id didStart_swizzle_blockImp = ^(id selfRef, WKWebView *webView, WKNavigation *navigation) {
+    id didStart_swizzle_blockImp = ^(id<NSObject> selfRef, WKWebView *webView, WKNavigation *navigation) {
         RPTLog(@"didStart_swizzle_blockImp called");
         
         SEL selector = @selector(webView:didStartProvisionalNavigation:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             ((void(*)(id, SEL, id, id))originalImp)(selfRef, selector, webView, navigation);
@@ -136,11 +136,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
                     types:"v@:@@"];
     
     // MARK: WKNavigationDelegate webView:didFinishNavigation:
-    id didFinishNavigation_swizzle_blockImp = ^(id selfRef, WKWebView *webView, WKNavigation *navigation) {
+    id didFinishNavigation_swizzle_blockImp = ^(id<NSObject> selfRef, WKWebView *webView, WKNavigation *navigation) {
         RPTLog(@"didFinishNavigation_swizzle_blockImp called");
         
         SEL selector = @selector(webView:didFinishNavigation:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             ((void(*)(id, SEL, id, id))originalImp)(selfRef, selector, webView, navigation);
@@ -154,11 +154,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
                     types:"v@:@@"];
     
     // MARK: WKNavigationDelegate webView:didFailNavigation:withError:
-    id didFailNavigation_swizzle_blockImp = ^(id selfRef, WKWebView *webView, WKNavigation *navigation, NSError *error) {
+    id didFailNavigation_swizzle_blockImp = ^(id<NSObject> selfRef, WKWebView *webView, WKNavigation *navigation, NSError *error) {
         RPTLog(@"didFailNavigation_swizzle_blockImp called");
         
         SEL selector = @selector(webView:didFailNavigation:withError:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             ((void(*)(id, SEL, id, id, id))originalImp)(selfRef, selector, webView, navigation, error);
@@ -172,11 +172,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
                     types:"v@:@@@"];
     
     // MARK: WKNavigationDelegate webView:didFailProvisionalNavigation:withError:
-    id didFailProvisionalNavigation_swizzle_blockImp = ^(id selfRef, WKWebView *webView, WKNavigation *navigation, NSError *error) {
+    id didFailProvisionalNavigation_swizzle_blockImp = ^(id<NSObject> selfRef, WKWebView *webView, WKNavigation *navigation, NSError *error) {
         RPTLog(@"didFailProvisionalNavigation_swizzle_blockImp called");
         
         SEL selector = @selector(webView:didFailProvisionalNavigation:withError:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             ((void(*)(id, SEL, id, id, id))originalImp)(selfRef, selector, webView, navigation, error);
@@ -190,11 +190,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
                     types:"v@:@@@"];
     
     // MARK: WKNavigationDelegate webViewWebContentProcessDidTerminate:
-    id webContentProcessDidTerminate_swizzle_blockImp = ^(id selfRef, WKWebView *webView) {
+    id webContentProcessDidTerminate_swizzle_blockImp = ^(id<NSObject> selfRef, WKWebView *webView) {
         RPTLog(@"webContentProcessDidTerminate_swizzle_blockImp called");
         
         SEL selector = @selector(webViewWebContentProcessDidTerminate:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             ((void(*)(id, SEL, id))originalImp)(selfRef, selector, webView);
@@ -208,11 +208,11 @@ static void endTrackingWithWKWebView(WKWebView *webView)
                     types:"v@:@"];
     
     // MARK: WKNavigationDelegate webView:didReceiveServerRedirectForProvisionalNavigation:
-    id didReceiveServerRedirect_swizzle_blockImp = ^(id selfRef, WKWebView *webView, WKNavigation *navigation) {
+    id didReceiveServerRedirect_swizzle_blockImp = ^(id<NSObject> selfRef, WKWebView *webView, WKNavigation *navigation) {
         RPTLog(@"didReceiveServerRedirect_swizzle_blockImp called");
         
         SEL selector = @selector(webView:didReceiveServerRedirectForProvisionalNavigation:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:((Class)selfRef).class];
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
         if (originalImp)
         {
             ((void(*)(id, SEL, id, id))originalImp)(selfRef, selector, webView, navigation);

--- a/RPerformanceTracking/Private/_RPTClassManipulator.h
+++ b/RPerformanceTracking/Private/_RPTClassManipulator.h
@@ -45,7 +45,7 @@ RPT_EXPORT @interface _RPTClassManipulator : NSObject
 // makes us compatible with 3rd party SDK swizzlers e.g. New Relic)
 + (void)swizzleSelector:(SEL)sel onClass:(Class)recipient newImplementation:(IMP)newImp types:(const char *)types;
 
-+ (IMP)implementationForOriginalSelector:(SEL)selector class:(Class)className;
++ (_Nullable IMP)implementationForOriginalSelector:(SEL)selector class:(Class)className;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SwizzleTests.m
+++ b/Tests/SwizzleTests.m
@@ -1,0 +1,115 @@
+@import XCTest;
+#import <OCMock/OCMock.h>
+#import "_RPTClassManipulator.h"
+
+@interface _RPTClassManipulator ()
++ (void)_removeSwizzleSelector:(SEL)sel onClass:(Class)recipient types:(const char *)types;
+@end
+
+@interface SwizzleTests : XCTestCase
+@property (nonatomic) BOOL originalCalled;
+@property (nonatomic) BOOL swizzleCalled;
+@end
+
+@implementation SwizzleTests
+
+- (void)setUp
+{
+    _originalCalled = NO;
+    _swizzleCalled = NO;
+}
+
+- (void)aMethodWithParam1:(id)param1 param2:(NSString *)param2 param3:(NSInteger)param3
+{
+    _originalCalled = YES;
+    
+    // Ensure parameters are being passed correctly from swizzle IMP
+    XCTAssert([param1 isKindOfClass:NSValue.class]);
+    XCTAssert([param2 isKindOfClass:NSString.class]);
+    XCTAssert(param3 == 5);
+}
+
+- (void)setupSwizzleHasOriginalMethod
+{
+    id swizzle_blockImp = ^(id<NSObject> selfRef, id param1, NSString *param2, NSInteger param3) {
+        
+        XCTAssert([param1 isKindOfClass:NSValue.class]);
+        XCTAssert([param2 isKindOfClass:NSString.class]);
+        XCTAssert(param3 == 5);
+        
+        self.swizzleCalled = YES;
+        
+        SEL selector = @selector(aMethodWithParam1:param2:param3:);
+        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
+        if (originalImp)
+        {
+            ((void(*)(id, SEL, id, id, NSInteger))originalImp)(selfRef, selector, param1, param2, param3);
+        }
+    };
+    [_RPTClassManipulator swizzleSelector:@selector(aMethodWithParam1:param2:param3:)
+                                  onClass:self.class
+                        newImplementation:imp_implementationWithBlock(swizzle_blockImp)
+                                    types:"v@:@@i"];
+}
+
+- (void)removeSwizzleHasOriginalMethod
+{
+    [_RPTClassManipulator _removeSwizzleSelector:@selector(aMethodWithParam1:param2:param3:)
+                                         onClass:self.class
+                                           types:"v@:@@i"];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+- (void)setupSwizzleNoOriginalMethod
+{
+    id swizzle_blockImp = ^(id<NSObject> selfRef, id param1) {
+        self.swizzleCalled = YES;
+    };
+
+    [_RPTClassManipulator swizzleSelector:@selector(aMethodThatDoesntExist:)
+                                  onClass:self.class
+                        newImplementation:imp_implementationWithBlock(swizzle_blockImp)
+                                    types:"v@:@"];
+}
+
+- (void)testThatSwizzleIsCalled
+{
+    [self setupSwizzleHasOriginalMethod];
+    [self aMethodWithParam1:[NSValue valueWithCGRect:CGRectZero] param2:@"test" param3:5];
+    XCTAssert(_swizzleCalled);
+    [self removeSwizzleHasOriginalMethod];
+}
+
+- (void)testThatOriginalMethodIsCalled
+{
+    [self setupSwizzleHasOriginalMethod];
+    [self aMethodWithParam1:[NSValue valueWithCGRect:CGRectZero] param2:@"test" param3:5];
+    XCTAssert(_originalCalled);
+    [self removeSwizzleHasOriginalMethod];
+}
+
+- (void)testThatSwizzleCanBeRemoved
+{
+    [self setupSwizzleHasOriginalMethod];
+    [self removeSwizzleHasOriginalMethod];
+    [self aMethodWithParam1:[NSValue valueWithCGRect:CGRectZero] param2:@"test" param3:5];
+    XCTAssert(!_swizzleCalled);
+}
+
+- (void)testThatOriginalIsCalledAfterSwizzleRemoved
+{
+    [self setupSwizzleHasOriginalMethod];
+    [self removeSwizzleHasOriginalMethod];
+    [self aMethodWithParam1:[NSValue valueWithCGRect:CGRectZero] param2:@"test" param3:5];
+    XCTAssert(_originalCalled);
+}
+
+- (void)testThatSwizzleIsCalledWhenNoOriginalMethod
+{
+    [self setupSwizzleNoOriginalMethod];
+    [self performSelector:@selector(aMethodThatDoesntExist:) withObject:@1];
+    XCTAssert(_swizzleCalled);
+}
+#pragma clang diagnostic pop
+@end


### PR DESCRIPTION
Also:
- add _RPTClassManipulator method to remove swizzles (mainly for unit testing)
- fix Xcode 9 UIStackView availability warning
- make the swizzle block selfRefs confirm to NSObject protocol so that the `class` message can be sent without casting