### PR TITLE
REM-25644 Disable NSURLProtocol tracking

### DIFF
--- a/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
@@ -17,7 +17,7 @@ static void startTrackingWithUIWebView(UIWebView *webView)
     NSURLRequest *request = webView.request;
 
     // bail out if there's no URL or if tracking is already done by _RPTNSURLProtocol
-    if (!request || !manager.disableProtocolWebviewObserving) return;
+    if (!request || manager.enableProtocolWebviewTracking) { return; }
 
     uint_fast64_t trackingIdentifier = [objc_getAssociatedObject(webView, _RPT_UIWEBVIEW_TRACKINGIDENTIFIER) unsignedLongLongValue];
 
@@ -40,7 +40,7 @@ static void endTrackingWithUIWebView(UIWebView *webView)
 
     uint_fast64_t trackingIdentifier = [objc_getAssociatedObject(webView, _RPT_UIWEBVIEW_TRACKINGIDENTIFIER) unsignedLongLongValue];
 
-    if (trackingIdentifier && manager.disableProtocolWebviewObserving)
+    if (trackingIdentifier)
     {
         [manager.tracker end:trackingIdentifier];
     }
@@ -51,7 +51,7 @@ static void endTrackingWithUIWebView(UIWebView *webView)
 
 + (void)load
 {
-    if(![_RPTTrackingManager sharedInstance].disableProtocolWebviewObserving)
+    if([_RPTTrackingManager sharedInstance].enableProtocolWebviewTracking)
     {
         [NSURLProtocol registerClass:[_RPTNSURLProtocol class]];
         return;

--- a/RPerformanceTracking/Private/_RPTNSURLProtocol.m
+++ b/RPerformanceTracking/Private/_RPTNSURLProtocol.m
@@ -56,7 +56,7 @@ extern NSURLCacheStoragePolicy CacheStoragePolicyForRequestAndResponse(NSURLRequ
     self.connection = dataTask;
     
     // we are generating a NSURLSessionTask to load this request therefore tracking loading
-    // state will be handled by NSURLSessionTask+RPerformanceTracking#_rpt_setState:
+    // state will be handled by NSURLSessionTask swizzling
     [self.connection resume];
 }
 

--- a/RPerformanceTracking/Private/_RPTTrackingManager.h
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.h
@@ -9,7 +9,7 @@ RPT_EXPORT @interface _RPTTrackingManager : NSObject
 @property (nonatomic, readonly) _RPTRingBuffer    *ringBuffer;
 @property (nonatomic, readonly) _RPTTracker       *tracker;
 @property (nonatomic, readonly) _RPTSender        *sender;
-@property (nonatomic)           BOOL               disableProtocolWebviewObserving;
+@property (nonatomic)           BOOL               enableProtocolWebviewTracking;
 @property (nonatomic, copy)     NSString          *currentScreen;
 
 + (instancetype)sharedInstance;

--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -96,7 +96,7 @@ RPT_EXPORT @interface _RPTTrackingKey : NSObject<NSCopying>
 #if DEBUG
         _forceTrackingEnabled = [[appBundle objectForInfoDictionaryKey:@"RPTForceTrackingEnabled"] boolValue];
 #endif
-        _disableProtocolWebviewObserving = [[appBundle objectForInfoDictionaryKey:@"RPTDisableProtocolWebviewObserving"] boolValue];
+        _enableProtocolWebviewTracking = [[appBundle objectForInfoDictionaryKey:@"RPTEnableProtocolWebviewTracking"] boolValue];
         
         do
         {

--- a/Tests/HostApp/Info.plist
+++ b/Tests/HostApp/Info.plist
@@ -30,8 +30,6 @@
 	<string>RELAYAPP_ID</string>
 	<key>RPTSubscriptionKey</key>
 	<string>SUBSCRIPTION_KEY</string>
-	<key>RPTDisableProtocolWebviewObserving</key>
-	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Tests/TrackingManagerTests.m
+++ b/Tests/TrackingManagerTests.m
@@ -406,4 +406,31 @@ static const NSUInteger     TRACKING_DATA_LIMIT  = 100u;
     }    
 }
 
+- (void)testThatNSURLProtocolTrackingIsDisabledWhenPlistEnableKeyIsNotPresent
+{
+    // plist does not contain key so no need to mock bundle
+    _RPTTrackingManager *trackingManager = [_RPTTrackingManager.alloc init];
+    XCTAssertFalse(trackingManager.enableProtocolWebviewTracking);
+}
+
+- (void)testThatNSURLProtocolTrackingIsDisabledWhenPlistEnableKeyIsFalse
+{
+    id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"RPTEnableProtocolWebviewTracking"]).andReturn(@NO);
+    
+    _RPTTrackingManager *trackingManager = [_RPTTrackingManager.alloc init];
+    XCTAssertFalse(trackingManager.enableProtocolWebviewTracking);
+    [mockBundle stopMocking];
+}
+
+- (void)testThatNSURLProtocolTrackingIsEnabledWhenPlistEnableKeyIsTrue
+{
+    id mockBundle = OCMPartialMock([NSBundle mainBundle]);
+    OCMStub([mockBundle objectForInfoDictionaryKey:@"RPTEnableProtocolWebviewTracking"]).andReturn(@YES);
+    
+    _RPTTrackingManager *trackingManager = [_RPTTrackingManager.alloc init];
+    XCTAssertTrue(trackingManager.enableProtocolWebviewTracking);
+    [mockBundle stopMocking];
+}
+
 @end


### PR DESCRIPTION
- default behaviour is to disable NSURLProtocol tracking because it is experimental/risky
- it must be explicitly enabled in the plist by `RPTEnableProtocolWebviewTracking` boolean flag
- change tracking manager 'disable' property to an 'enable' property and update affected logic