### PR TITLE
fix(metric): REM-25743 use timeIntervalSince1970 for start/end time

### DIFF
--- a/RPerformanceTracking/Private/_RPTMainThreadWatcher.m
+++ b/RPerformanceTracking/Private/_RPTMainThreadWatcher.m
@@ -31,7 +31,7 @@
     while (!self.isCancelled)
     {
         _watcherRunning = YES;
-        _startTime = [NSDate timeIntervalSinceReferenceDate];
+        _startTime = [NSDate.date timeIntervalSince1970];
         
         // If this block doesn't get to run on the main thread in
         // <= blockThreshold seconds then we consider the main
@@ -46,7 +46,7 @@
         if (_watcherRunning)
         {
             // Main thread has been blocked for at least 'threshold' seconds
-            _endTime = [NSDate timeIntervalSinceReferenceDate];
+            _endTime = [NSDate.date timeIntervalSince1970];
             RPTLog(@"Thread watcher: main thread blocked");
 
             uint_fast64_t ti = [_RPTTrackingManager.sharedInstance.tracker addDevice:@"main_thread_blocked" start:_startTime end:_endTime];


### PR DESCRIPTION
- use timeIntervalSince1970 for start/end time of device metric so we are consistent with other time intervals in codebase
- add unit test and refactor tests

Verified change on sample app: device main_thread_blocked metric start time is logged as "1520304119781" which converts to GMT: Tuesday, March 6, 2018 2:41:59.781 AM on https://www.epochconverter.com.