### PR TITLE
APTT-15 Disabled measurements collection when no active metric exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ osx_image: xcode9.1
 
 before_install:
 - gem update fastlane --no-ri --no-rdoc --no-document
+- pod repo update
 
 script: fastlane ci
 

--- a/Podfile
+++ b/Podfile
@@ -4,6 +4,8 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'Tests' do
+  pod 'Kiwi',            '~> 3.0.0'
+  pod 'Underscore.m',    '~> 0.3.0'
   pod 'OCMock',          '~> 3.2'
   pod 'OHHTTPStubs',     '~> 4.7.0'
   pod 'OHHTTPStubs/HTTPMessage'

--- a/RPerformanceTracking.xcodeproj/project.pbxproj
+++ b/RPerformanceTracking.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		1696C3CA207714D700288BB5 /* RPTConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1696C3C9207714D700288BB5 /* RPTConfigurationTests.m */; };
 		1696C3CD2077157200288BB5 /* TestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1696C3CC2077157200288BB5 /* TestUtils.m */; };
-		3059D7739CD8B79D17CD17F0 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDB01895B3BE708F72F5A39E /* Pods_Tests.framework */; };
 		5A8CF0CD1E9C76A1006E7544 /* UIControlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CF0CC1E9C76A1006E7544 /* UIControlTests.m */; };
 		5A8CF0D61E9CAECD006E7544 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CF0D51E9CAECD006E7544 /* main.m */; };
 		5A8CF0D91E9CAECD006E7544 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CF0D81E9CAECD006E7544 /* AppDelegate.m */; };
@@ -81,15 +80,12 @@
 		6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainThreadWatcherTests.m; sourceTree = "<group>"; };
 		6DA949E21E94E09600856C95 /* SenderIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenderIntegrationTests.m; sourceTree = "<group>"; };
 		6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwizzleTests.m; sourceTree = "<group>"; };
-		988FCCF899B088ADB0143DA0 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		C80E064B1EA876FF00FD22D2 /* TrackingManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TrackingManagerTests.m; sourceTree = "<group>"; };
 		C83BA79F1EDEA2150048D5C5 /* UITableViewCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UITableViewCellTests.m; sourceTree = "<group>"; };
 		C85DC3E91EA084B800F79E52 /* RingBufferTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RingBufferTests.m; sourceTree = "<group>"; };
 		C8B86DF61EC1749A00C7B8DD /* UIWebViewHookTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIWebViewHookTests.m; sourceTree = "<group>"; };
 		C8D893911EBAF8AE001A6CEC /* WKWebViewHookTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WKWebViewHookTests.m; sourceTree = "<group>"; };
 		C8D982DE1F18D83C0088EBEC /* LocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocationTests.m; sourceTree = "<group>"; };
-		EDB01895B3BE708F72F5A39E /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EFFF2714E574EC6B4044AF7E /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,30 +100,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3059D7739CD8B79D17CD17F0 /* Pods_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1D4654F35995C40E519856FD /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				988FCCF899B088ADB0143DA0 /* Pods-Tests.debug.xcconfig */,
-				EFFF2714E574EC6B4044AF7E /* Pods-Tests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		4B907587F6AE9D21CECCDDE9 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				EDB01895B3BE708F72F5A39E /* Pods_Tests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		5A8CF0D31E9CAECD006E7544 /* HostApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,8 +170,6 @@
 			children = (
 				69194F731CED9D3500879A11 /* Tests */,
 				69194F721CED9D3400879A11 /* Tests.xctest */,
-				1D4654F35995C40E519856FD /* Pods */,
-				4B907587F6AE9D21CECCDDE9 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -221,11 +197,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 69194F791CED9D3500879A11 /* Build configuration list for PBXNativeTarget "Tests" */;
 			buildPhases = (
-				C4A55FBD53B7B8A35F12DC18 /* [CP] Check Pods Manifest.lock */,
 				69194F6E1CED9D3400879A11 /* Sources */,
 				69194F6F1CED9D3400879A11 /* Frameworks */,
 				69194F701CED9D3400879A11 /* Resources */,
-				6EB584AABB516A92D441AEFA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -297,53 +271,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		6EB584AABB516A92D441AEFA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Kiwi/Kiwi.framework",
-				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
-				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/RPerformanceTracking/RPerformanceTracking.framework",
-				"${BUILT_PRODUCTS_DIR}/Underscore.m/Underscore_m.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kiwi.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RPerformanceTracking.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Underscore_m.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C4A55FBD53B7B8A35F12DC18 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Tests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		5A8CF0CE1E9CAECD006E7544 /* Sources */ = {
@@ -514,7 +441,6 @@
 		};
 		69194F771CED9D3500879A11 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 988FCCF899B088ADB0143DA0 /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -565,7 +491,6 @@
 		};
 		69194F781CED9D3500879A11 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EFFF2714E574EC6B4044AF7E /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/RPerformanceTracking.xcodeproj/project.pbxproj
+++ b/RPerformanceTracking.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1696C3CA207714D700288BB5 /* RPTConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1696C3C9207714D700288BB5 /* RPTConfigurationTests.m */; };
+		1696C3CD2077157200288BB5 /* TestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1696C3CC2077157200288BB5 /* TestUtils.m */; };
+		3059D7739CD8B79D17CD17F0 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDB01895B3BE708F72F5A39E /* Pods_Tests.framework */; };
 		5A8CF0CD1E9C76A1006E7544 /* UIControlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CF0CC1E9C76A1006E7544 /* UIControlTests.m */; };
 		5A8CF0D61E9CAECD006E7544 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CF0D51E9CAECD006E7544 /* main.m */; };
 		5A8CF0D91E9CAECD006E7544 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CF0D81E9CAECD006E7544 /* AppDelegate.m */; };
@@ -47,6 +50,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1696C3C9207714D700288BB5 /* RPTConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RPTConfigurationTests.m; sourceTree = "<group>"; };
+		1696C3CB2077157200288BB5 /* TestUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtils.h; sourceTree = "<group>"; };
+		1696C3CC2077157200288BB5 /* TestUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestUtils.m; sourceTree = "<group>"; };
 		5A8CF0CC1E9C76A1006E7544 /* UIControlTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIControlTests.m; sourceTree = "<group>"; };
 		5A8CF0D21E9CAECD006E7544 /* HostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A8CF0D51E9CAECD006E7544 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -75,12 +81,15 @@
 		6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainThreadWatcherTests.m; sourceTree = "<group>"; };
 		6DA949E21E94E09600856C95 /* SenderIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenderIntegrationTests.m; sourceTree = "<group>"; };
 		6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwizzleTests.m; sourceTree = "<group>"; };
+		988FCCF899B088ADB0143DA0 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		C80E064B1EA876FF00FD22D2 /* TrackingManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TrackingManagerTests.m; sourceTree = "<group>"; };
 		C83BA79F1EDEA2150048D5C5 /* UITableViewCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UITableViewCellTests.m; sourceTree = "<group>"; };
 		C85DC3E91EA084B800F79E52 /* RingBufferTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RingBufferTests.m; sourceTree = "<group>"; };
 		C8B86DF61EC1749A00C7B8DD /* UIWebViewHookTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIWebViewHookTests.m; sourceTree = "<group>"; };
 		C8D893911EBAF8AE001A6CEC /* WKWebViewHookTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WKWebViewHookTests.m; sourceTree = "<group>"; };
 		C8D982DE1F18D83C0088EBEC /* LocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocationTests.m; sourceTree = "<group>"; };
+		EDB01895B3BE708F72F5A39E /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EFFF2714E574EC6B4044AF7E /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,12 +104,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3059D7739CD8B79D17CD17F0 /* Pods_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1D4654F35995C40E519856FD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				988FCCF899B088ADB0143DA0 /* Pods-Tests.debug.xcconfig */,
+				EFFF2714E574EC6B4044AF7E /* Pods-Tests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4B907587F6AE9D21CECCDDE9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EDB01895B3BE708F72F5A39E /* Pods_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		5A8CF0D31E9CAECD006E7544 /* HostApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -153,6 +180,9 @@
 				6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */,
 				6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */,
 				5AEE76CC200C7FD500891D8E /* URLProtocolTests.m */,
+				1696C3C9207714D700288BB5 /* RPTConfigurationTests.m */,
+				1696C3CB2077157200288BB5 /* TestUtils.h */,
+				1696C3CC2077157200288BB5 /* TestUtils.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -162,6 +192,8 @@
 			children = (
 				69194F731CED9D3500879A11 /* Tests */,
 				69194F721CED9D3400879A11 /* Tests.xctest */,
+				1D4654F35995C40E519856FD /* Pods */,
+				4B907587F6AE9D21CECCDDE9 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -189,9 +221,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 69194F791CED9D3500879A11 /* Build configuration list for PBXNativeTarget "Tests" */;
 			buildPhases = (
+				C4A55FBD53B7B8A35F12DC18 /* [CP] Check Pods Manifest.lock */,
 				69194F6E1CED9D3400879A11 /* Sources */,
 				69194F6F1CED9D3400879A11 /* Frameworks */,
 				69194F701CED9D3400879A11 /* Resources */,
+				6EB584AABB516A92D441AEFA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -264,6 +298,53 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		6EB584AABB516A92D441AEFA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Kiwi/Kiwi.framework",
+				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
+				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
+				"${BUILT_PRODUCTS_DIR}/RPerformanceTracking/RPerformanceTracking.framework",
+				"${BUILT_PRODUCTS_DIR}/Underscore.m/Underscore_m.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kiwi.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RPerformanceTracking.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Underscore_m.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C4A55FBD53B7B8A35F12DC18 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		5A8CF0CE1E9CAECD006E7544 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -286,12 +367,14 @@
 				5A8CF0CD1E9C76A1006E7544 /* UIControlTests.m in Sources */,
 				6D64251D1EB8611C00755DA3 /* ConfigTests.m in Sources */,
 				5AB9C6641E8366300066C5CB /* EventWriterTests.m in Sources */,
+				1696C3CA207714D700288BB5 /* RPTConfigurationTests.m in Sources */,
 				C8D893921EBAF8AE001A6CEC /* WKWebViewHookTests.m in Sources */,
 				5A91BD641EB096210048689C /* UICollectionViewTests.m in Sources */,
 				C8B86DF71EC1749A00C7B8DD /* UIWebViewHookTests.m in Sources */,
 				6DDD80CB1FF22BC7002DED2E /* SwizzleTests.m in Sources */,
 				5AC8DD3C1E95E3B80067995E /* UIViewControllerTests.m in Sources */,
 				5AC8DDC81E96354D0067995E /* TestViewController.m in Sources */,
+				1696C3CD2077157200288BB5 /* TestUtils.m in Sources */,
 				5AEE76CD200C7FD600891D8E /* URLProtocolTests.m in Sources */,
 				6DA30F6B1FAAF501006A4DE6 /* MainThreadWatcherTests.m in Sources */,
 				C8D982DF1F18D83C0088EBEC /* LocationTests.m in Sources */,
@@ -431,6 +514,7 @@
 		};
 		69194F771CED9D3500879A11 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 988FCCF899B088ADB0143DA0 /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -481,6 +565,7 @@
 		};
 		69194F781CED9D3500879A11 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EFFF2714E574EC6B4044AF7E /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/RPerformanceTracking.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/RPerformanceTracking.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
@@ -75,6 +76,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/RPerformanceTracking/Private/_RPTConfiguration.h
+++ b/RPerformanceTracking/Private/_RPTConfiguration.h
@@ -19,6 +19,11 @@ RPT_EXPORT @interface _RPTConfiguration : NSObject
 @property (nonatomic, readonly) double activationRatio;
 
 /*
+ * Should track events when no metric available
+ */
+@property (nonatomic, readonly) BOOL shouldTrackNonMetricMeasurements;
+
+/*
  * Load configuration from disk if it exists there, or return the default configuration if not.
  */
 + (instancetype)loadConfiguration;

--- a/RPerformanceTracking/Private/_RPTConfiguration.m
+++ b/RPerformanceTracking/Private/_RPTConfiguration.m
@@ -1,6 +1,5 @@
 #import "_RPTConfiguration.h"
 
-
 static NSString *const KEY = @"com.rakuten.performancetracking";
 
 /* RPT_EXPORT */ @implementation _RPTConfiguration
@@ -30,6 +29,12 @@ static NSString *const KEY = @"com.rakuten.performancetracking";
 
         NSURL *url = [NSURL URLWithString:urlString];
         if (!url) break;
+        
+        NSString* enableNonMetricMeasurement = values[@"enableNonMetricMeasurement"];
+        BOOL shouldTrackNonMetricMeasurements = YES;
+        if ([enableNonMetricMeasurement isKindOfClass:NSNumber.class])  {
+            shouldTrackNonMetricMeasurements = [enableNonMetricMeasurement boolValue];
+        }
 
         NSDictionary *headerFields = values[@"sendHeaders"];
         if (![headerFields isKindOfClass:NSDictionary.class]) break;
@@ -56,6 +61,7 @@ static NSString *const KEY = @"com.rakuten.performancetracking";
             _activationRatio          = activationRatio;
             _eventHubURL              = url;
             _eventHubHTTPHeaderFields = headerFields;
+            _shouldTrackNonMetricMeasurements = shouldTrackNonMetricMeasurements;
         }
         return self;
     } while(0);

--- a/RPerformanceTracking/Private/_RPTConfiguration.m
+++ b/RPerformanceTracking/Private/_RPTConfiguration.m
@@ -30,7 +30,7 @@ static NSString *const KEY = @"com.rakuten.performancetracking";
         NSURL *url = [NSURL URLWithString:urlString];
         if (!url) break;
         
-        NSString* enableNonMetricMeasurement = values[@"enableNonMetricMeasurement"];
+        NSNumber* enableNonMetricMeasurement = values[@"enableNonMetricMeasurement"];
         BOOL shouldTrackNonMetricMeasurements = YES;
         if ([enableNonMetricMeasurement isKindOfClass:NSNumber.class])  {
             shouldTrackNonMetricMeasurements = [enableNonMetricMeasurement boolValue];

--- a/RPerformanceTracking/Private/_RPTTracker.h
+++ b/RPerformanceTracking/Private/_RPTTracker.h
@@ -7,6 +7,8 @@ NS_ASSUME_NONNULL_BEGIN
 RPT_EXPORT @interface _RPTTracker : NSObject
 @property (nonatomic, readonly) _RPTRingBuffer *ringBuffer;
 
+@property (nonatomic) BOOL shouldTrackNonMetricMeasurements;
+
 - (void)startMetric:(NSString *)metric;
 - (void)prolongMetric;
 - (void)endMetric;

--- a/RPerformanceTracking/Private/_RPTTracker.m
+++ b/RPerformanceTracking/Private/_RPTTracker.m
@@ -21,10 +21,10 @@
     @synchronized(self)
     {
         _currentMetric = nil;
-        _RPTMetric *metric = [_RPTMetric new];
+        _RPTMetric* metric = [_RPTMetric new];
         metric.identifier = metricIdentifier;
 
-        _RPTMeasurement *measurement = [self _startWithKind:_RPTMetricMeasurementKind receiver:metric method:nil];
+        _RPTMeasurement *measurement = [self _startWithKind:_RPTMetricMeasurementKind receiver:metric method:nil metric:metric];
         if (measurement)
         {
             metric.startTime = measurement.startTime;
@@ -110,6 +110,18 @@
 
 - (_RPTMeasurement *)_startWithKind:(_RPTMeasurementKind)kind receiver:(NSObject *)receiver method:(nullable NSString *)method
 {
+    return [self _startWithKind:kind
+                       receiver:receiver
+                         method:method
+                         metric:_currentMetric];
+}
+
+- (_RPTMeasurement *)_startWithKind:(_RPTMeasurementKind)kind receiver:(NSObject *)receiver method:(nullable NSString *)method metric:(_RPTMetric*)metric {
+    
+    if (!_shouldTrackNonMetricMeasurements && !metric) {
+        return nil;
+    }
+    
     _RPTMeasurement *measurement = _ringBuffer.nextMeasurement;
     if (measurement)
     {
@@ -131,6 +143,7 @@
     {
         _ringBuffer = ringBuffer;
         _currentMetric = currentMetric;
+        _shouldTrackNonMetricMeasurements = YES;
     }
     return self;
 }

--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -115,6 +115,7 @@ RPT_EXPORT @interface _RPTTrackingKey : NSObject<NSCopying>
             
             _tracker = [_RPTTracker.alloc initWithRingBuffer:_ringBuffer currentMetric:_currentMetric];
             if (!_tracker) return nil;
+            _tracker.shouldTrackNonMetricMeasurements = _configuration.shouldTrackNonMetricMeasurements;
             
             _eventWriter = [_RPTEventWriter.alloc initWithConfiguration:_configuration];
             if (!_eventWriter) return nil;

--- a/Tests/MainThreadWatcherTests.m
+++ b/Tests/MainThreadWatcherTests.m
@@ -91,6 +91,7 @@ static const NSTimeInterval BLOCK_THRESHOLD = 0.4;
 {
     NSDictionary* obj = @{ @"enablePercent": @(100),
                            @"sendUrl": @"https://blah.blah",
+                           @"enableNonMetricMeasurement": @"true",
                            @"sendHeaders": @{@"header1": @"update1",
                                              @"header2": @"update2"} };
     

--- a/Tests/RPTConfigurationTests.m
+++ b/Tests/RPTConfigurationTests.m
@@ -1,0 +1,36 @@
+#import <Kiwi/Kiwi.h>
+#import "_RPTConfiguration.h"
+
+#import "TestUtils.h"
+
+SPEC_BEGIN(RPTConfigurationTests)
+
+describe(@"RPTTracker", ^{
+    describe(@"initWithData:", ^{
+        it(@"should `shouldTrackNonMetricMeasurements` property as `YES` if `enableNonMetricMeasurement` payload field is not a number", ^{
+            NSData* payload = mkConfigPayload_(@{@"enableNonMetricMeasurement": [NSNull null]});
+            
+            _RPTConfiguration* config = [[_RPTConfiguration alloc] initWithData:payload];
+            
+            [[theValue(config.shouldTrackNonMetricMeasurements) should] beTrue];
+        });
+        
+        it(@"should set `shouldTrackNonMetricMeasurements` property as `YES` if `enableNonMetricMeasurement` payload field is `true`", ^{
+            NSData* payload = mkConfigPayload_(@{@"enableNonMetricMeasurement": @YES});
+            
+            _RPTConfiguration* config = [[_RPTConfiguration alloc] initWithData:payload];
+            
+            [[theValue(config.shouldTrackNonMetricMeasurements) should] beTrue];
+        });
+        
+        it(@"should set `shouldTrackNonMetricMeasurements` property as `NO` if `enableNonMetricMeasurement` payload field is not `true`", ^{
+            NSData* payload = mkConfigPayload_(@{@"enableNonMetricMeasurement": @NO});
+            
+            _RPTConfiguration* config = [[_RPTConfiguration alloc] initWithData:payload];
+            
+            [[theValue(config.shouldTrackNonMetricMeasurements) should] beFalse];
+        });
+    });
+});
+
+SPEC_END

--- a/Tests/SenderTests.m
+++ b/Tests/SenderTests.m
@@ -36,6 +36,7 @@ static const NSUInteger      MAX_MEASUREMENTS    = 512u;
     NSDictionary *dict = @{
                            @"enablePercent": @(100),
                            @"sendUrl": @"https://performance-endpoint.com/measurements/messages?timeout=60&api-version=2014-01",
+                           @"enableNonMetricMeasurement": @"true",
                            @"sendHeaders":@{@"Authorization": @"SharedAccessSignature sr=foo",
                                             @"Content-Type": @"application/atom+xml;type=entry;charset=utf-8",
                                             @"BrokerProperties": @"PartitionKey: ABC"

--- a/Tests/TestUtils.h
+++ b/Tests/TestUtils.h
@@ -1,0 +1,14 @@
+#ifndef TestUtils_h
+#define TestUtils_h
+
+@class _RPTTracker, _RPTMetric, _RPTMeasurement, _RPTRingBuffer, _RPTConfiguration;
+
+NSData* mkConfigPayload_(NSDictionary* params);
+
+_RPTMeasurement* mkMeasurementStub(NSDictionary* params);
+_RPTRingBuffer* mkRingBufferStub(NSDictionary* params);
+_RPTMetric* mkMetricStub(NSDictionary* params);
+_RPTConfiguration* mkConfigurationStub(NSDictionary* params);
+
+#endif
+

--- a/Tests/TestUtils.m
+++ b/Tests/TestUtils.m
@@ -1,0 +1,66 @@
+#import <Kiwi/Kiwi.h>
+#import <Underscore_m/Underscore.h>
+
+#import "_RPTTracker.h"
+#import "_RPTRingBuffer.h"
+#import "_RPTMeasurement.h"
+#import "_RPTMetric.h"
+#import "_RPTConfiguration.h"
+
+NSData* mkConfigPayload_(NSDictionary* params) {
+    NSDictionary* payload = Underscore.defaults(params ? params : @{}, @{
+        @"enablePercent": @(100),
+        @"sendUrl": @"https://blah.blah",
+        @"enableNonMetricMeasurement": @"true",
+        @"sendHeaders": @{@"header1": @"value1", @"header2": @"value2"}
+    });
+    
+    return [NSJSONSerialization dataWithJSONObject:payload options:NSJSONWritingPrettyPrinted error:0];
+}
+
+_RPTMeasurement* mkMeasurementStub(NSDictionary* params) {
+    params = Underscore.defaults(params ? params : @{}, @{
+        @"trackingIdentifier": theValue(-1)
+    });
+    
+    _RPTMeasurement* measurement = [_RPTMeasurement nullMock];
+    
+    [measurement stub:@selector(trackingIdentifier) andReturn:params[@"trackingIdentifier"]];
+    
+    return measurement;
+}
+
+
+_RPTRingBuffer* mkRingBufferStub(NSDictionary* params) {
+    params = Underscore.defaults(params ? params : @{}, @{
+        @"nextMeasurement": mkMeasurementStub(nil)
+    });
+    
+    _RPTRingBuffer* buffer = [_RPTRingBuffer nullMock];
+    
+    [buffer stub:@selector(nextMeasurement) andReturn:params[@"nextMeasurement"]];
+    
+    return buffer;
+}
+
+_RPTMetric* mkMetricStub(NSDictionary* params) {
+    return [_RPTMetric nullMock];
+}
+
+_RPTConfiguration* mkConfigurationStub(NSDictionary* params) {
+    params = Underscore.defaults(params ? params : @{}, @{
+        @"activationRatio": @(100),
+        @"eventHubURL": [NSURL URLWithString:@"https://default.event.hub.url"],
+        @"eventHubHTTPHeaderFields": @{@"default_header": @"default_header_value"},
+        @"shouldTrackNonMetricMeasurements": @(YES)
+    });
+    
+    _RPTConfiguration* config = [_RPTConfiguration nullMock];
+    
+    [config stub:@selector(activationRatio) andReturn:params[@"activationRatio"]];
+    [config stub:@selector(eventHubURL) andReturn:params[@"eventHubURL"]];
+    [config stub:@selector(eventHubHTTPHeaderFields) andReturn:params[@"eventHubHTTPHeaderFields"]];
+    [config stub:@selector(shouldTrackNonMetricMeasurements) andReturn:@"shouldTrackNonMetricMeasurements"];
+    
+    return config;
+}

--- a/Tests/TrackerTests.m
+++ b/Tests/TrackerTests.m
@@ -6,6 +6,124 @@
 #import "_RPTMetric.h"
 #import "_RPTMeasurement.h"
 
+#import <Kiwi/Kiwi.h>
+#import <Underscore_m/Underscore.h>
+
+#import "TestUtils.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+
+SPEC_BEGIN(RPTTRackerTests)
+
+describe(@"RPTTracker", ^{
+    describe(@"constructor", ^{
+        it(@"should enable tracking by default", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil)
+                                                          currentMetric:mkMetricStub(nil)
+                                   ];
+            
+            [[theValue(tracker.shouldTrackNonMetricMeasurements) should] equal:theValue(YES)];
+        });
+    });
+    
+    describe(@"startMetric:", ^{        
+        it(@"should start metric if configured to not track non-metric measurements", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = NO;
+            
+            [tracker startMetric:@"some_metric"];
+            
+            // measurements can be tracked only when metric started if `shouldTrackNonMetricMeasurements` == NO
+            [[theValue([tracker startCustom:@"some_measurement"]) shouldNot] equal:theValue(0)];
+        });
+    });
+    
+    describe(@"startMethod:receiver:", ^{
+        it(@"should not start tracking measurement if tracking non-metric measurements disabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = NO;
+            
+            uint_fast64_t measurementId = [tracker startMethod:@"some_method" receiver:[NSObject nullMock]];
+            
+            [[theValue(measurementId) should] equal:theValue(0)];
+        });
+        
+        it(@"should start tracking meaurement if tracking non-metric measurements enabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = YES;
+            
+            uint_fast64_t measurementId = [tracker startMethod:@"some_method" receiver:[NSObject nullMock]];
+            
+            [[theValue(measurementId) shouldNot] equal:theValue(0)];
+        });
+    });
+    
+    describe(@"startRequest", ^{
+        it(@"should not start tracking measurement if tracking non-metric measurements disabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = NO;
+            
+            uint_fast64_t measurementId = [tracker startRequest:[NSURLRequest nullMock]];
+            
+            [[theValue(measurementId) should] equal:theValue(0)];
+        });
+        
+        it(@"should start tracking meaurement if tracking non-metric measurements enabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = YES;
+            
+            uint_fast64_t measurementId = [tracker startRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com"]]];
+            
+            [[theValue(measurementId) shouldNot] equal:theValue(0)];
+        });
+    });
+    
+    describe(@"startCustom:", ^{
+        it(@"should not start tracking measurement if tracking non-metric measurements disabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = NO;
+            
+            uint_fast64_t measurementId = [tracker startCustom:@"custrom_metric"];
+            
+            [[theValue(measurementId) should] equal:theValue(0)];
+        });
+        
+        it(@"should start tracking meaurement if tracking non-metric measurements enabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = YES;
+            
+            uint_fast64_t measurementId = [tracker startCustom:@"custrom_metric"];
+            
+            [[theValue(measurementId) shouldNot] equal:theValue(0)];
+        });
+    });
+    
+    describe(@"addDevice", ^{
+        it(@"should not start tracking measurement if tracking non-metric measurements disabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = NO;
+            
+            uint_fast64_t measurementId = [tracker addDevice:@"device_id" start:0 end:1];
+            
+            [[theValue(measurementId) should] equal:theValue(0)];
+        });
+        
+        it(@"should start tracking meaurement if tracking non-metric measurements enabled and no active metric exists", ^{
+            _RPTTracker* tracker = [_RPTTracker.alloc initWithRingBuffer:mkRingBufferStub(nil) currentMetric:nil];
+            tracker.shouldTrackNonMetricMeasurements = YES;
+            
+            uint_fast64_t measurementId = [tracker addDevice:@"device_id" start:0 end:1];
+            
+            [[theValue(measurementId) shouldNot] equal:theValue(0)];
+        });
+    });
+});
+
+SPEC_END
+
+#pragma clang diagnostic pop
+
 @interface _RPTTracker ()
 @property (atomic) _RPTMetric *currentMetric;
 @end

--- a/Tests/TrackingManagerTests.m
+++ b/Tests/TrackingManagerTests.m
@@ -50,6 +50,7 @@ static const NSUInteger     TRACKING_DATA_LIMIT  = 100u;
     NSDictionary *dict = @{
                            @"enablePercent": @(100),
                            @"sendUrl": @"https://performance-endpoint.com/measurements/messages?timeout=60&api-version=2014-01",
+                           @"enableNonMetricMeasurement": @"true",
                            @"sendHeaders":@{@"Authorization": @"SharedAccessSignature sr=foo",
                                             @"Content-Type": @"application/atom+xml;type=entry;charset=utf-8",
                                             @"BrokerProperties": @"PartitionKey: ABC"


### PR DESCRIPTION
Prevented measurements creation in _RPTracker for all measurement creation methods.
Ensured that metric is still created when collection of non-metric measurements disabled.
Added Kiwi BDD framework to the project, implemented unit-tests for new feature in BDD style.
Slightly fixed _RPTrackingManager configuration tests.