### PR TITLE
Fixed warnings in project code

### DIFF
--- a/RPerformanceTracking/Private/_RPTClassManipulator+NSURLSessionTask.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+NSURLSessionTask.m
@@ -66,8 +66,6 @@ void _handleChangedState(NSURLSessionTask *task, NSURLSessionTaskState state)
     }
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
 + (void)_swizzleTaskSetState
 {
     NSURLSession *session = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.defaultSessionConfiguration];
@@ -87,7 +85,7 @@ void _handleChangedState(NSURLSessionTask *task, NSURLSessionTaskState state)
 
         _handleChangedState((NSURLSessionTask *)selfRef, state);
         
-        SEL selector = @selector(setState:);
+        SEL selector = NSSelectorFromString(@"setState:");
         IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:dataTaskClass];
         
         if (originalImp)
@@ -96,12 +94,12 @@ void _handleChangedState(NSURLSessionTask *task, NSURLSessionTaskState state)
         }
     };
     
-    [self swizzleSelector:@selector(setState:)
+    [self swizzleSelector:NSSelectorFromString(@"setState:")
                   onClass:dataTaskClass
         newImplementation:imp_implementationWithBlock(setState_swizzle_blockImp)
                     types:"v@:l"];
     
     [session invalidateAndCancel];
 }
-#pragma clang diagnostic pop
+
 @end

--- a/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
@@ -43,7 +43,8 @@ static void endTrackingWithUIWebView(UIWebView *webView)
     if (trackingIdentifier)
     {
         // Update status code
-        NSCachedURLResponse *urlResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:webView.request];
+        NSURLRequest* request = webView.request;
+        NSCachedURLResponse *urlResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:request];
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)urlResponse.response;
         if (httpResponse.URL)
         {

--- a/RPerformanceTracking/Private/_RPTClassManipulator+WKWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+WKWebView.m
@@ -262,7 +262,8 @@ static void updateStatusCodeForWebView(NSInteger statusCode, WKWebView *webView)
         if ([navigationResponse.response isKindOfClass:[NSHTTPURLResponse class]])
         {
             NSHTTPURLResponse *response = (NSHTTPURLResponse *)navigationResponse.response;
-            if (response.URL && [response.URL.absoluteString isEqualToString:webView.URL.absoluteString])
+            NSString* urlString = webView.URL.absoluteString;
+            if (response.URL && [response.URL.absoluteString isEqualToString:urlString])
             {
                 updateStatusCodeForWebView(response.statusCode, webView);
             }

--- a/RPerformanceTracking/Private/_RPTConfiguration.m
+++ b/RPerformanceTracking/Private/_RPTConfiguration.m
@@ -4,8 +4,6 @@ static NSString *const KEY = @"com.rakuten.performancetracking";
 
 /* RPT_EXPORT */ @implementation _RPTConfiguration
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wassign-enum"
 - (instancetype)initWithData:(NSData *)data
 {
     do
@@ -68,8 +66,6 @@ static NSString *const KEY = @"com.rakuten.performancetracking";
 
     return nil; // invalid object
 }
-#pragma clang diagnostic pop
-
 
 + (instancetype)loadConfiguration
 {

--- a/RPerformanceTracking/Private/_RPTLocation.m
+++ b/RPerformanceTracking/Private/_RPTLocation.m
@@ -4,8 +4,6 @@ static NSString *const KEY = @"com.rakuten.performancetracking.location";
 
 /* RPT_EXPORT */ @implementation _RPTLocation
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wassign-enum"
 - (instancetype)initWithData:(NSData *)data
 {
 	do
@@ -48,8 +46,6 @@ static NSString *const KEY = @"com.rakuten.performancetracking.location";
 	
 	return nil; // invalid object
 }
-
-#pragma clang diagnostic pop
 
 + (instancetype)loadLocation
 {

--- a/RPerformanceTracking/Private/_RPTMeasurement.m
+++ b/RPerformanceTracking/Private/_RPTMeasurement.m
@@ -13,8 +13,6 @@ const NSTimeInterval _RPT_MEASUREMENT_MAXTIME = 30.0;
     return self;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wassign-enum"
 - (void)clear
 {
     _kind               = 0;
@@ -26,10 +24,9 @@ const NSTimeInterval _RPT_MEASUREMENT_MAXTIME = 30.0;
     _screen             = nil;
     _statusCode         = 0;
 }
-#pragma clang diagnostic pop
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"Measurement<%p>: kind %lu trackingId %llu startTime %f endTime %f receiver %@ method %@ screen %@ statusCode %d", self, (unsigned long)_kind, (unsigned long long)_trackingIdentifier, _startTime, _endTime, _receiver, _method, _screen, _statusCode];
+    return [NSString stringWithFormat:@"Measurement<%p>: kind %lu trackingId %llu startTime %f endTime %f receiver %@ method %@ screen %@ statusCode %ld", self, (unsigned long)_kind, (unsigned long long)_trackingIdentifier, _startTime, _endTime, _receiver, _method, _screen, (long)_statusCode];
 }
 @end

--- a/RPerformanceTracking/Private/_RPTMetric.m
+++ b/RPerformanceTracking/Private/_RPTMetric.m
@@ -9,24 +9,22 @@ const NSTimeInterval _RPT_METRIC_MAXTIME = 10.0;
     return self.identifier.hash ^ [@(self.startTime) hash] ^ [@(self.endTime) hash] ^ [@(self.urlCount) hash];
 }
 
-
-//FIXME : fix "-Wnullable-to-nonnull-conversion" warning, then remove pragma
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
 - (BOOL)isEqual:(_RPTMetric *)other
 {
     // Only the identifier and the object participate in equality testing
     if (self == other) return YES;
 
     if (![other isMemberOfClass:self.class]) return NO;
+    
+    NSString* ownId = self.identifier;
+    NSString* otherId = other.identifier;
 
     return
-    ((!self.identifier && !other.identifier) || (self.identifier && other.identifier && [self.identifier isEqualToString:other.identifier]))
+    ((!ownId && !otherId) || (ownId && otherId && [ownId isEqualToString:otherId]))
     && (self.startTime == other.startTime)
     && (self.endTime == other.endTime)
     && (self.urlCount == other.urlCount);
 }
-#pragma clang diagnostic pop
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {

--- a/RPerformanceTracking/Private/_RPTNSURLProtocol.m
+++ b/RPerformanceTracking/Private/_RPTNSURLProtocol.m
@@ -14,11 +14,6 @@ extern NSURLCacheStoragePolicy CacheStoragePolicyForRequestAndResponse(NSURLRequ
 
 @implementation _RPTNSURLProtocol
 
-// FIXME : fix "-Wnullable-to-nonnull-conversion" && "-Wunused-parameter" warning, then remove pragma
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
 {
     NSString *scheme = request.URL.scheme.lowercaseString;
@@ -65,6 +60,9 @@ extern NSURLCacheStoragePolicy CacheStoragePolicyForRequestAndResponse(NSURLRequ
     [self.connection cancel];
 }
 
+// URL Session passes extra params to CB which we do not process
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
     [self.client URLProtocol:self didLoadData:data];
@@ -125,6 +123,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
     NSURLAuthenticationChallenge* challengeWrapper = [[NSURLAuthenticationChallenge alloc] initWithAuthenticationChallenge:challenge sender:sender];
     [self.client URLProtocol:self didReceiveAuthenticationChallenge:challengeWrapper];
 }
+#pragma clang diagnostic pop
 
 // Based on https://developer.apple.com/library/content/samplecode/CustomHTTPProtocol/Listings/Read_Me_About_CustomHTTPProtocol_txt.html
 extern NSURLCacheStoragePolicy CacheStoragePolicyForRequestAndResponse(NSURLRequest * request, NSHTTPURLResponse * response)

--- a/RPerformanceTracking/Private/_RPTSessionChallengeSender.m
+++ b/RPerformanceTracking/Private/_RPTSessionChallengeSender.m
@@ -10,7 +10,7 @@
 
 @implementation _RPTSessionChallengeSender
 
-// FIXME : fix "-Wunused-parameter" warning, then remove pragma
+// Some params of NSURLAuthenticationChallengeSender methods are not being used.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 - (instancetype)initWithSessionCompletionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler

--- a/RPerformanceTracking/Private/_RPTTrackingManager.h
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.h
@@ -17,8 +17,8 @@ RPT_EXPORT @interface _RPTTrackingManager : NSObject
 
 - (void)startMetric:(NSString *)metric;
 - (void)prolongMetric;
-- (void)startMeasurement:(NSString *)measurement object:(NSObject *)object;
-- (void)endMeasurement:(NSString *)measurement object:(NSObject *)object;
+- (void)startMeasurement:(NSString *)measurement object:(nullable NSObject *)object;
+- (void)endMeasurement:(NSString *)measurement object:(nullable NSObject *)object;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RPerformanceTracking/RPTPerformanceMeasurement.h
+++ b/RPerformanceTracking/RPTPerformanceMeasurement.h
@@ -23,13 +23,13 @@ RPT_EXPORT @interface RPTPerformanceMeasurement : NSObject
  * @param identifier Identifier of the measurement to start tracking.
  * @param object     Associated object for aggregating the measurement.
  */
-+ (void)startAggregated:(NSString *)identifier object:(NSObject *)object;
++ (void)startAggregated:(NSString *)identifier object:(nullable NSObject *)object;
 
 /**
  * @param identifier Identifier of the measurement to stop tracking.
  * @param object     Associated object for aggregating the measurement.
  */
-+ (void)endAggregated:(NSString *)identifier object:(NSObject *)object;
++ (void)endAggregated:(NSString *)identifier object:(nullable NSObject *)object;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RPerformanceTracking/RPTPerformanceMeasurement.m
+++ b/RPerformanceTracking/RPTPerformanceMeasurement.m
@@ -3,9 +3,6 @@
 
 /* RPT_EXPORT */ @implementation RPTPerformanceMeasurement
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-
 + (void)start:(NSString *)identifier
 {
     [self startAggregated:identifier object:nil];
@@ -16,14 +13,12 @@
     [self endAggregated:identifier object:nil];
 }
 
-#pragma clang diagnostic pop
-
-+ (void)startAggregated:(NSString *)identifier object:(NSObject *)object
++ (void)startAggregated:(NSString *)identifier object:(nullable NSObject *)object
 {
     [_RPTTrackingManager.sharedInstance startMeasurement:identifier object:object];
 }
 
-+ (void)endAggregated:(NSString *)identifier object:(NSObject *)object
++ (void)endAggregated:(NSString *)identifier object:(nullable NSObject *)object
 {
     [_RPTTrackingManager.sharedInstance endMeasurement:identifier object:object];
 }


### PR DESCRIPTION
Fixed existing warnings. Removed warnings suppressions, fixed suppressed warnings.
Preserved suppressions for unused param warnings because it comes from protocol method
implementations, which does not require full set of passed params.

Resolves AAPT-23