### PR TITLE
WebView send measurements without metric

### DIFF
--- a/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+UIWebView.m
@@ -9,12 +9,10 @@
 
 static const void *_RPT_UIWEBVIEW_TRACKINGIDENTIFIER = &_RPT_UIWEBVIEW_TRACKINGIDENTIFIER;
 
-static void startTrackingWithUIWebView(UIWebView *webView)
+static void startTrackingWithUIWebViewWithRequest(UIWebView *webView, NSURLRequest *request)
 {
     _RPTTrackingManager *manager = [_RPTTrackingManager sharedInstance];
     [manager.tracker prolongMetric];
-
-    NSURLRequest *request = webView.request;
 
     // bail out if there's no URL or if tracking is already done by _RPTNSURLProtocol
     if (!request || manager.enableProtocolWebviewTracking) { return; }
@@ -36,23 +34,23 @@ static void endTrackingWithUIWebView(UIWebView *webView)
 {
     _RPTTrackingManager *manager = [_RPTTrackingManager sharedInstance];
     [manager.tracker prolongMetric];
-    [manager.tracker endMetric];
+
+    NSURLRequest* request = webView.request;
+    NSURL *url = request.URL;
+    NSCachedURLResponse *urlResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:request];
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)urlResponse.response;
+    NSInteger statusCode = httpResponse.statusCode;
 
     uint_fast64_t trackingIdentifier = [objc_getAssociatedObject(webView, _RPT_UIWEBVIEW_TRACKINGIDENTIFIER) unsignedLongLongValue];
-
-    if (trackingIdentifier)
+    if (trackingIdentifier && url)
     {
         // Update status code
-        NSURLRequest* request = webView.request;
-        NSCachedURLResponse *urlResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:request];
-        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)urlResponse.response;
-        if (httpResponse.URL)
-        {
-            [_RPTTrackingManager.sharedInstance.tracker updateStatusCode:httpResponse.statusCode trackingIdentifier:trackingIdentifier];
-        }
+        [manager.tracker updateURL:url trackingIdentifier:trackingIdentifier];
+        [manager.tracker updateStatusCode:statusCode trackingIdentifier:trackingIdentifier];
         [manager.tracker end:trackingIdentifier];
+        objc_setAssociatedObject(webView, _RPT_UIWEBVIEW_TRACKINGIDENTIFIER, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    objc_setAssociatedObject(webView, _RPT_UIWEBVIEW_TRACKINGIDENTIFIER, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [manager.tracker endMetric];
 }
 
 @implementation _RPTClassManipulator (UIWebView)
@@ -79,7 +77,11 @@ static void endTrackingWithUIWebView(UIWebView *webView)
         RPTLogVerbose(@"UIWebView loadRequest_swizzle_blockImp called");
 
         if (request.URL) { [[_RPTTrackingManager sharedInstance].tracker prolongMetric]; }
-
+        if ([selfRef isKindOfClass:UIWebView.class])
+        {
+            UIWebView *webView = (UIWebView*)selfRef;
+            startTrackingWithUIWebViewWithRequest(webView, request);
+        }
         SEL selector = @selector(loadRequest:);
         IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:UIWebView.class];
 
@@ -119,24 +121,6 @@ static void endTrackingWithUIWebView(UIWebView *webView)
 + (void)_swizzleUIWebViewDelegate:(id<UIWebViewDelegate>)delegate
 {
     Class recipient = delegate.class;
-
-    // MARK: UIWebViewDelegate webViewDidStartLoad:
-    id webViewDidStartLoad_swizzle_blockImp = ^(id<NSObject> selfRef, UIWebView *webView) {
-        RPTLogVerbose(@"UIWevView webViewDidStartLoad_swizzle_blockImp called");
-
-        SEL selector = @selector(webViewDidStartLoad:);
-        IMP originalImp = [_RPTClassManipulator implementationForOriginalSelector:selector class:selfRef.class];
-        if (originalImp)
-        {
-            ((void(*)(id, SEL, id))originalImp)(selfRef, selector, webView);
-        }
-
-        startTrackingWithUIWebView(webView);
-    };
-    [self swizzleSelector:@selector(webViewDidStartLoad:)
-                  onClass:recipient
-        newImplementation:imp_implementationWithBlock(webViewDidStartLoad_swizzle_blockImp)
-                    types:"v@:@"];
 
     // MARK: UIWebViewDelegate webViewDidFinishLoad:
     id webViewDidFinishLoad_swizzle_blockImp = ^(id<NSObject> selfRef, UIWebView *webView) {

--- a/RPerformanceTracking/Private/_RPTClassManipulator+WKWebView.m
+++ b/RPerformanceTracking/Private/_RPTClassManipulator+WKWebView.m
@@ -11,14 +11,15 @@ static const void *_RPT_WKWEBVIEW_TRACKINGIDENTIFIER = &_RPT_WKWEBVIEW_TRACKINGI
 
 static void startTrackingWithWKWebView(WKWebView *webView)
 {
-    [_RPTTrackingManager.sharedInstance.tracker prolongMetric];
+    _RPTTrackingManager *manager = [_RPTTrackingManager sharedInstance];
+    [manager.tracker prolongMetric];
 
     uint_fast64_t trackingIdentifier = [objc_getAssociatedObject(webView, _RPT_WKWEBVIEW_TRACKINGIDENTIFIER) unsignedLongLongValue];
     
     NSURL *webViewURL = webView.URL;
     if (!trackingIdentifier && webViewURL)
     {
-        trackingIdentifier = [_RPTTrackingManager.sharedInstance.tracker startRequest:[NSURLRequest requestWithURL:webViewURL]];
+        trackingIdentifier = [manager.tracker startRequest:[NSURLRequest requestWithURL:webViewURL]];
         if (trackingIdentifier)
         {
             objc_setAssociatedObject(webView, _RPT_WKWEBVIEW_TRACKINGIDENTIFIER, [NSNumber numberWithUnsignedLongLong:trackingIdentifier], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -28,25 +29,27 @@ static void startTrackingWithWKWebView(WKWebView *webView)
 
 static void endTrackingWithWKWebView(WKWebView *webView)
 {
-    [_RPTTrackingManager.sharedInstance.tracker prolongMetric];
-    [_RPTTrackingManager.sharedInstance.tracker endMetric];
-    
+    _RPTTrackingManager *manager = [_RPTTrackingManager sharedInstance];
+    [manager.tracker prolongMetric];
+
     uint_fast64_t trackingIdentifier = [objc_getAssociatedObject(webView, _RPT_WKWEBVIEW_TRACKINGIDENTIFIER) unsignedLongLongValue];
     if (trackingIdentifier)
     {
-        [_RPTTrackingManager.sharedInstance.tracker end:trackingIdentifier];
+        [manager.tracker end:trackingIdentifier];
+        objc_setAssociatedObject(webView, _RPT_WKWEBVIEW_TRACKINGIDENTIFIER, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    objc_setAssociatedObject(webView, _RPT_WKWEBVIEW_TRACKINGIDENTIFIER, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [manager.tracker endMetric];
 }
 
 static void updateStatusCodeForWebView(NSInteger statusCode, WKWebView *webView)
 {
-    [_RPTTrackingManager.sharedInstance.tracker prolongMetric];
+    _RPTTrackingManager *manager = [_RPTTrackingManager sharedInstance];
+    [manager.tracker prolongMetric];
 
     uint_fast64_t trackingIdentifier = [objc_getAssociatedObject(webView, _RPT_WKWEBVIEW_TRACKINGIDENTIFIER) unsignedLongLongValue];
     if (trackingIdentifier)
     {
-        [_RPTTrackingManager.sharedInstance.tracker updateStatusCode:statusCode trackingIdentifier:trackingIdentifier];
+        [manager.tracker updateStatusCode:statusCode trackingIdentifier:trackingIdentifier];
     }
 }
 

--- a/RPerformanceTracking/Private/_RPTSender.m
+++ b/RPerformanceTracking/Private/_RPTSender.m
@@ -8,7 +8,8 @@
 
 static const NSInteger      MIN_COUNT                   = 10;
 static const NSTimeInterval SLEEP_INTERVAL_SECONDS      = 10.0; // 10s
-static const NSTimeInterval MIN_TIME                    = 5.0 / 1000; // 5ms
+static const NSTimeInterval MIN_TIME_METRIC             = 5.0 / 1000; // 5ms
+static const NSTimeInterval MIN_TIME_MEASUREMENT        = 1.0 / 1000; // 1ms
 static const NSTimeInterval SLEEP_MAX_INTERVAL          = 1800; // 30 minutes
 
 @interface _RPTTrackingManager()
@@ -193,7 +194,7 @@ static const NSTimeInterval SLEEP_MAX_INTERVAL          = 1800; // 30 minutes
 
 - (void)writeMetric:(_RPTMetric *)metric
 {
-    if (metric.endTime - metric.startTime < MIN_TIME) { return; }
+    if (metric.endTime - metric.startTime < MIN_TIME_METRIC) { return; }
 
     if (!_sentCount) { [_eventWriter begin]; }
 
@@ -203,7 +204,7 @@ static const NSTimeInterval SLEEP_MAX_INTERVAL          = 1800; // 30 minutes
 
 - (void)writeMeasurement:(_RPTMeasurement *)measurement metricId:(NSString *)metricId
 {
-    if (measurement.endTime - measurement.startTime < MIN_TIME) { return; }
+    if (measurement.endTime - measurement.startTime < MIN_TIME_MEASUREMENT) { return; }
 
     if (!_sentCount) { [_eventWriter begin]; }
 

--- a/RPerformanceTracking/Private/_RPTTracker.h
+++ b/RPerformanceTracking/Private/_RPTTracker.h
@@ -19,6 +19,7 @@ RPT_EXPORT @interface _RPTTracker : NSObject
 - (uint_fast64_t)addDevice:(NSString *)name start:(NSTimeInterval)startTime end:(NSTimeInterval)endTime;
 - (void)end:(uint_fast64_t)trackingIdentifier;
 - (void)updateStatusCode:(NSInteger)statusCode trackingIdentifier:(uint_fast64_t)trackingIdentifier;
+- (void)updateURL:(NSURL *)url trackingIdentifier:(uint_fast64_t)trackingIdentifier;
 
 - (instancetype)initWithRingBuffer:(_RPTRingBuffer *)ringBuffer currentMetric:(_RPTMetric *)currentMetric NS_DESIGNATED_INITIALIZER;
 @end

--- a/RPerformanceTracking/Private/_RPTTracker.m
+++ b/RPerformanceTracking/Private/_RPTTracker.m
@@ -111,6 +111,18 @@
     }
 }
 
+- (void)updateURL:(NSURL *)url trackingIdentifier:(uint_fast64_t)trackingIdentifier
+{
+    if (trackingIdentifier)
+    {
+        _RPTMeasurement *measurement = [_ringBuffer measurementWithTrackingIdentifier:trackingIdentifier];
+        if (measurement.kind == _RPTURLMeasurementKind)
+        {
+            measurement.receiver = url.absoluteString;
+        }
+    }
+}
+
 - (_RPTMeasurement *)_startWithKind:(_RPTMeasurementKind)kind receiver:(NSObject *)receiver method:(nullable NSString *)method
 {
     return [self _startWithKind:kind

--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -10,7 +10,6 @@
 #import "_RPTLocation.h"
 #import "_RPTMainThreadWatcher.h"
 #import "_RPTEnvironment.h"
-#import "_RPTClassManipulator.h"
 
 static const NSUInteger      MAX_MEASUREMENTS               = 512u;
 static const NSUInteger      TRACKING_DATA_LIMIT            = 100u;

--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -10,6 +10,7 @@
 #import "_RPTLocation.h"
 #import "_RPTMainThreadWatcher.h"
 #import "_RPTEnvironment.h"
+#import "_RPTClassManipulator.h"
 
 static const NSUInteger      MAX_MEASUREMENTS               = 512u;
 static const NSUInteger      TRACKING_DATA_LIMIT            = 100u;

--- a/Tests/UIWebViewHookTests.m
+++ b/Tests/UIWebViewHookTests.m
@@ -31,14 +31,15 @@
 @property (nonatomic) UIWebView             *webView;
 @end
 
-@interface WebViewControllerChild : WebViewController <UIWebViewDelegate>
+@interface WebViewControllerFirstChild : WebViewController <UIWebViewDelegate>
+@property (nonatomic) UIWebView             *webViewInChild;
+@end
+
+@interface WebViewControllerSecondChild : WebViewController <UIWebViewDelegate>
 @property (nonatomic) UIWebView             *webViewInChild;
 @end
 
 @implementation WebViewController
-- (void)webViewDidStartLoad:(UIWebView *)webView
-{
-}
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
@@ -49,12 +50,23 @@
 }
 @end
 
-@implementation WebViewControllerChild
-- (void)webViewDidStartLoad:(UIWebView *)webView
+@implementation WebViewControllerFirstChild
+- (void)webViewDidFinishLoad:(UIWebView *)webView
 {
-    [super webViewDidStartLoad:webView];
+    [super webViewDidFinishLoad:webView];
 }
 
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    // intentionally do not call super
+}
+
+- (void)methodNotImplementedInSuperclass
+{
+}
+@end
+
+@implementation WebViewControllerSecondChild
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
 {
     // intentionally do not call super
@@ -140,11 +152,21 @@
 
 // MARK: Delegate inheritance tests
 
+- (void)testWebViewDelegateSubclassedMethodCallsSuper
+{
+    id mockTracker = OCMPartialMock(self.trackingManager.tracker);
+    WebViewControllerFirstChild *child = [self firstChildWebViewController];
+    [child.webViewInChild.delegate webViewDidFinishLoad:child.webViewInChild];
+
+    OCMVerify([mockTracker endMetric]);
+    [mockTracker stopMocking];
+}
+
 - (void)testWebViewDelegateSubclassedMethodIsForwardedToParent
 {
     id mockTracker = OCMPartialMock(self.trackingManager.tracker);
     
-    WebViewControllerChild *child = [self childWebViewController];
+    WebViewControllerSecondChild *child = [self secondChildWebViewController];
     [child.webViewInChild.delegate webViewDidFinishLoad:child.webViewInChild];
     
     OCMVerify([mockTracker endMetric]);
@@ -157,7 +179,7 @@
 {
     id mockTracker = OCMPartialMock(self.trackingManager.tracker);
     
-    WebViewControllerChild *child = [self childWebViewController];
+    WebViewControllerFirstChild *child = [self firstChildWebViewController];
     [child.webViewInChild.delegate webView:child.webViewInChild didFailLoadWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:nil]];
     
     OCMVerify([mockTracker endMetric]);
@@ -177,16 +199,29 @@
 {
 }
 
-- (WebViewControllerChild *)childWebViewController
+- (WebViewControllerFirstChild *)firstChildWebViewController
 {
     WebViewController *parent = WebViewController.new;
     parent.webView = [UIWebView.alloc initWithFrame:CGRectMake(0, 0, 200, 300)];
     parent.webView.delegate = parent;
     
-    WebViewControllerChild *child = WebViewControllerChild.new;
+    WebViewControllerFirstChild *child = WebViewControllerFirstChild.new;
     child.webViewInChild = [UIWebView.alloc initWithFrame:CGRectMake(0, 0, 200, 300)];
     child.webViewInChild.delegate = child;
     
+    return child;
+}
+
+- (WebViewControllerSecondChild *)secondChildWebViewController
+{
+    WebViewController *parent = WebViewController.new;
+    parent.webView = [UIWebView.alloc initWithFrame:CGRectMake(0, 0, 200, 300)];
+    parent.webView.delegate = parent;
+
+    WebViewControllerSecondChild *child = WebViewControllerSecondChild.new;
+    child.webViewInChild = [UIWebView.alloc initWithFrame:CGRectMake(0, 0, 200, 300)];
+    child.webViewInChild.delegate = child;
+
     return child;
 }
 

--- a/Tests/UIWebViewHookTests.m
+++ b/Tests/UIWebViewHookTests.m
@@ -106,14 +106,6 @@
     [mockTracker stopMocking];
 }
 
-- (void)testProlongMetricCalledOnWebViewDidStartLoad
-{
-    id mockTracker = OCMPartialMock(_trackingManager.tracker);
-    [_webView.delegate webViewDidStartLoad:_webView];
-    OCMVerify([mockTracker prolongMetric]);
-    [mockTracker stopMocking];
-}
-
 - (void)testProlongMetricCalledOnWebViewDidFinishLoad
 {
     id mockTracker = OCMPartialMock(_trackingManager.tracker);
@@ -147,17 +139,6 @@
 }
 
 // MARK: Delegate inheritance tests
-
-- (void)testWebViewDelegateSubclassedMethodCallsSuper
-{
-    id mockTracker = OCMPartialMock(self.trackingManager.tracker);
-    
-    WebViewControllerChild *child = [self childWebViewController];
-    [child.webViewInChild.delegate webViewDidStartLoad:child.webViewInChild];
-    
-    OCMVerify([mockTracker prolongMetric]);
-    [mockTracker stopMocking];
-}
 
 - (void)testWebViewDelegateSubclassedMethodIsForwardedToParent
 {


### PR DESCRIPTION
Change the order of calling end: metric method. (The metric is ended and set to nil before the measurement is ended, so the measurement has no metric)
Set the min time of measurement to 1ms.
Start the URL measurement in loadRequest: method.

Tested on the device(iOS 11)