### PR TITLE
fix: use a fixed size 64-bit variable to store the arc4random max value

### DIFF
--- a/RPerformanceTracking/Private/_RPTTrackingManager.m
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.m
@@ -17,7 +17,7 @@ static const NSUInteger      TRACKING_DATA_LIMIT            = 100u;
 
 static NSString *const       METRIC_LAUNCH                  = @"_launch";
 
-static const NSUInteger      ARCRANDOM_MAX              = 0x100000000;
+static const uint64_t        ARCRANDOM_MAX                  = 0x100000000;
 
 static const NSTimeInterval  REFRESH_CONFIG_INTERVAL        = 3600.0; // 1 hour
 static const NSTimeInterval  MAIN_THREAD_BLOCK_THRESHOLD    = 0.4;


### PR DESCRIPTION
- https://developer.apple.com/documentation/objectivec/nsuinteger?language=objc on 32-bit device archs NSUInteger is 32 bits which overflows when it tries to store the ARCRANDOM_MAX value
- instead use a fixed-size variable that guarantees not to overflow on 32/64 bit archs
- resolves APTT-759