### PR TITLE
Add diagnostic logging for a timed out metric APTT-780

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,34 @@
+# mostly based on https://github.com/NYTimes/objective-c-style-guide
+---
+# common
+SortIncludes: false
+UseTab: Never
+---
+Language:        ObjC
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterEnum: true
+    AfterControlStatement: false
+    AfterFunction: false
+    AfterObjCDeclaration: true
+    BeforeCatch: true
+    BeforeElse: true
+ColumnLimit: 0
+IndentWidth: 4
+MaxEmptyLinesToKeep: 1
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PointerBindsToType: false
+SpacesBeforeTrailingComments: 1
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesInContainerLiterals: false
+---
+Language: Cpp
+DisableFormat: true

--- a/RPerformanceTracking.xcodeproj/project.pbxproj
+++ b/RPerformanceTracking.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		6D312C621EA5D98D00467620 /* NetworkSessionHookTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D312C611EA5D98D00467620 /* NetworkSessionHookTests.m */; };
 		6D3DBD4A1E824A9B00B97E89 /* SenderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D3DBD491E824A9B00B97E89 /* SenderTests.m */; };
 		6D64251D1EB8611C00755DA3 /* ConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D64251C1EB8611C00755DA3 /* ConfigTests.m */; };
+		6D872183223A484A0010BA2F /* MetricTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D872182223A484A0010BA2F /* MetricTests.m */; };
 		6DA30F6B1FAAF501006A4DE6 /* MainThreadWatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */; };
 		6DDD80CB1FF22BC7002DED2E /* SwizzleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */; };
 		C80E064C1EA876FF00FD22D2 /* TrackingManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C80E064B1EA876FF00FD22D2 /* TrackingManagerTests.m */; };
@@ -91,6 +92,7 @@
 		6D312C611EA5D98D00467620 /* NetworkSessionHookTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NetworkSessionHookTests.m; sourceTree = "<group>"; };
 		6D3DBD491E824A9B00B97E89 /* SenderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenderTests.m; sourceTree = "<group>"; };
 		6D64251C1EB8611C00755DA3 /* ConfigTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConfigTests.m; sourceTree = "<group>"; };
+		6D872182223A484A0010BA2F /* MetricTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MetricTests.m; sourceTree = "<group>"; };
 		6DA30F6A1FAAF501006A4DE6 /* MainThreadWatcherTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainThreadWatcherTests.m; sourceTree = "<group>"; };
 		6DA949E21E94E09600856C95 /* SenderIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenderIntegrationTests.m; sourceTree = "<group>"; };
 		6DDD80CA1FF22BC7002DED2E /* SwizzleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SwizzleTests.m; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				5A57326F20EB56710050B152 /* RingBufferTestsKiwi.m */,
 				5AF6FD4421914F5900EA8C3B /* RPTEventBroadcastTests.m */,
 				5ABA1A712193D15D00CED97D /* HelperTests.m */,
+				6D872182223A484A0010BA2F /* MetricTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -195,7 +198,15 @@
 				69194F731CED9D3500879A11 /* Tests */,
 				69194F721CED9D3400879A11 /* UnitTests.xctest */,
 				5AEA72D620E4605B00D0D4E0 /* FunctionalTests.xctest */,
+				FACB0AC4E83C85EB3B087CFB /* Pods */,
 			);
+			sourceTree = "<group>";
+		};
+		FACB0AC4E83C85EB3B087CFB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -358,6 +369,7 @@
 				5A8CF0CD1E9C76A1006E7544 /* UIControlTests.m in Sources */,
 				6D64251D1EB8611C00755DA3 /* ConfigTests.m in Sources */,
 				5A57327020EB56710050B152 /* RingBufferTestsKiwi.m in Sources */,
+				6D872183223A484A0010BA2F /* MetricTests.m in Sources */,
 				16932AE92080508E00C91400 /* RPTEnvironmentTests.m in Sources */,
 				5AB9C6641E8366300066C5CB /* EventWriterTests.m in Sources */,
 				1696C3CA207714D700288BB5 /* RPTConfigurationTests.m in Sources */,

--- a/RPerformanceTracking/Private/_RPTMainThreadWatcher.m
+++ b/RPerformanceTracking/Private/_RPTMainThreadWatcher.m
@@ -47,10 +47,9 @@
         {
             // Main thread has been blocked for at least 'threshold' seconds
             _endTime = [NSDate.date timeIntervalSince1970];
-            RPTLog(@"Thread watcher: main thread blocked");
 
-            uint_fast64_t ti = [_RPTTrackingManager.sharedInstance.tracker addDevice:@"main_thread_blocked" start:_startTime end:_endTime];
-            if (!ti) RPTLog(@"Thread watcher: failed to add measurement");
+            RPTLog(@"Thread watcher: main thread blocked at least %f secs.", _blockThreshold);
+            [_RPTTrackingManager.sharedInstance.tracker addDevice:@"main_thread_blocked" start:_startTime end:_endTime];
         }
         
         dispatch_semaphore_wait(_semaphore, DISPATCH_TIME_FOREVER);

--- a/RPerformanceTracking/Private/_RPTMetric.h
+++ b/RPerformanceTracking/Private/_RPTMetric.h
@@ -2,13 +2,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-RPT_EXPORT const NSTimeInterval _RPT_METRIC_MAXTIME;
-
 RPT_EXPORT @interface _RPTMetric : NSObject<NSCopying>
 @property (nonatomic, copy, nullable) NSString        *identifier;
 @property (atomic)                    NSTimeInterval   startTime;
 @property (atomic)                    NSTimeInterval   endTime;
 @property (atomic)                    uint_fast64_t    urlCount;
+
++ (NSTimeInterval)maxDurationInSecs;
+- (BOOL)durationLessThanMax;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RPerformanceTracking/Private/_RPTMetric.m
+++ b/RPerformanceTracking/Private/_RPTMetric.m
@@ -36,4 +36,15 @@ const NSTimeInterval _RPT_METRIC_MAXTIME = 10.0;
     return copy;
 }
 
+- (BOOL)durationLessThanMax
+{
+    NSTimeInterval duration = _endTime - _startTime;
+    return duration < [self.class maxDurationInSecs];
+}
+
++ (NSTimeInterval)maxDurationInSecs
+{
+    return _RPT_METRIC_MAXTIME;
+}
+
 @end

--- a/RPerformanceTracking/Private/_RPTTracker.m
+++ b/RPerformanceTracking/Private/_RPTTracker.m
@@ -50,8 +50,11 @@
             
             metric.endTime = now;
             
-            if (now - metric.startTime > _RPT_METRIC_MAXTIME)
+            NSTimeInterval maxDurationInSecs = [_RPTMetric maxDurationInSecs];
+            if (now - metric.startTime > maxDurationInSecs)
             {
+                // Metric has timed out
+                RPTLog(@"Metric %@ that started at %@ has been nil'd because it exceeded the max duration of %f seconds when attempting to prolong it at %@", metric.identifier, [NSDate dateWithTimeIntervalSince1970:metric.startTime], maxDurationInSecs, [NSDate dateWithTimeIntervalSince1970:now]);
                 _currentMetric = nil;
             }
         }

--- a/Tests/MetricTests.m
+++ b/Tests/MetricTests.m
@@ -1,0 +1,48 @@
+#import <Kiwi/Kiwi.h>
+#import "_RPTMetric.h"
+
+SPEC_BEGIN(RPTMetricTests)
+
+describe(@"RPTMetric", ^{
+    describe(@"maxDurationInSecs", ^{
+        it(@"should return value 10.0", ^{
+            NSTimeInterval max = [_RPTMetric maxDurationInSecs];
+            
+            [[theValue(max) should] equal:theValue(10.0)];
+        });
+    });
+    
+    describe(@"durationLessThanMax", ^{
+        __block _RPTMetric *metric = _RPTMetric.new;
+        metric.identifier = @"identifier";
+        metric.urlCount = 0;
+        
+        it(@"should return true when duration < max", ^{
+            NSTimeInterval now = [NSDate.date timeIntervalSince1970];
+            metric.startTime = now - 5.0; // 5 secs in past
+            metric.endTime = now;
+            
+            [[theValue([metric durationLessThanMax]) should] beTrue];
+        });
+        
+        it(@"should return false when duration > max", ^{
+            NSTimeInterval now = [NSDate.date timeIntervalSince1970];
+            metric.startTime = now - 5.0;
+            metric.endTime = now + 10.0;
+            
+            [[theValue([metric durationLessThanMax]) should] beFalse];
+        });
+        
+        it(@"should return false when duration == max", ^{
+            NSTimeInterval now = [NSDate.date timeIntervalSince1970];
+            metric.startTime = now;
+            metric.endTime = now + 10.0;
+            
+            [[theValue([metric durationLessThanMax]) should] beFalse];
+        });
+    });
+    
+    // TODO: Tests for isEqual and copy
+});
+
+SPEC_END


### PR DESCRIPTION
- add explanatory comments to the sender algo
- only send the cached metric if its duration is < max
- make METRIC_MAXTIME private to the Metric model and expose it via a helper method, also add tests for helpers
- add the clang-format file
- ignore thread blocked add measurement return value and improve logging message