### PR TITLE
feat: expose the end metric API to client apps SDKCF-882

### DIFF
--- a/RPerformanceTracking.xcodeproj/project.pbxproj
+++ b/RPerformanceTracking.xcodeproj/project.pbxproj
@@ -198,15 +198,7 @@
 				69194F731CED9D3500879A11 /* Tests */,
 				69194F721CED9D3400879A11 /* UnitTests.xctest */,
 				5AEA72D620E4605B00D0D4E0 /* FunctionalTests.xctest */,
-				FACB0AC4E83C85EB3B087CFB /* Pods */,
 			);
-			sourceTree = "<group>";
-		};
-		FACB0AC4E83C85EB3B087CFB /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/RPerformanceTracking/Private/_RPTTrackingManager.h
+++ b/RPerformanceTracking/Private/_RPTTrackingManager.h
@@ -16,6 +16,7 @@ RPT_EXPORT @interface _RPTTrackingManager : NSObject
 
 - (void)startMetric:(NSString *)metric;
 - (void)prolongMetric;
+- (void)endMetric;
 - (void)startMeasurement:(NSString *)measurement object:(nullable NSObject *)object;
 - (void)endMeasurement:(NSString *)measurement object:(nullable NSObject *)object;
 @end

--- a/RPerformanceTracking/RPTPerformanceMetric.h
+++ b/RPerformanceTracking/RPTPerformanceMetric.h
@@ -20,6 +20,11 @@ RPT_EXPORT @interface RPTPerformanceMetric : NSObject
  * Prolong an existing metric.
  */
 + (void)prolong;
+
+/**
+ * End an existing metric.
+ */
++ (void)end;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RPerformanceTracking/RPTPerformanceMetric.m
+++ b/RPerformanceTracking/RPTPerformanceMetric.m
@@ -9,4 +9,8 @@
 + (void)prolong {
     [_RPTTrackingManager.sharedInstance prolongMetric];
 }
+
++ (void)end {
+    [_RPTTrackingManager.sharedInstance endMetric];
+}
 @end


### PR DESCRIPTION
- also remove a Pods reference from the project file that was left in by the deintegrate command after downgrading cocoapods from 1.6.0 to 1.5.3. See https://github.com/CocoaPods/CocoaPods/issues/8091