### PR TITLE
feat: allow the maximum metric duration to be set by a plist key

### DIFF
--- a/RPerformanceTracking/Private/_RPTConfiguration.m
+++ b/RPerformanceTracking/Private/_RPTConfiguration.m
@@ -115,12 +115,12 @@ static NSString *const KEY = @"com.rakuten.performancetracking";
 
     NSURLSessionConfiguration *sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration;
 
-    NSURL *base = environment.performanceTrackingBaseURL;
+    NSURL *base = environment.baseURL;
 #if DEBUG
     NSAssert(base, @"Your application's Info.plist must contain a key 'RPTConfigAPIEndpoint' set to the endpoint URL of your Config API");
 #endif
 
-    NSString *subscriptionKey = environment.performanceTrackingSubscriptionKey;
+    NSString *subscriptionKey = environment.subscriptionKey;
     if (subscriptionKey.length) {
         sessionConfiguration.HTTPAdditionalHeaders = @{@"apikey": subscriptionKey};
     }

--- a/RPerformanceTracking/Private/_RPTEnvironment.h
+++ b/RPerformanceTracking/Private/_RPTEnvironment.h
@@ -15,8 +15,9 @@ RPT_EXPORT @interface _RPTEnvironment : NSObject
 
 @property (nonatomic, readonly, copy, nullable) NSString *relayAppId;
 
-@property (nonatomic, readonly, copy, nullable) NSURL *performanceTrackingBaseURL;
-@property (nonatomic, readonly, copy, nullable) NSString *performanceTrackingSubscriptionKey;
+@property (nonatomic, readonly, copy, nullable) NSURL *baseURL;
+@property (nonatomic, readonly, copy, nullable) NSString *subscriptionKey;
+@property (nonatomic, readonly) NSTimeInterval maximumMetricDurationSeconds;
 
 @property (nonatomic, readonly, copy, nullable) NSString *deviceCountry;
 

--- a/RPerformanceTracking/Private/_RPTEnvironment.m
+++ b/RPerformanceTracking/Private/_RPTEnvironment.m
@@ -14,7 +14,7 @@ NSString *const RPTSDKVersion = @RPT_EXPAND_AND_QUOTE(RPT_SDK_VERSION);
 @interface _RPTEnvironment (Private)
 
 - (NSString *)determineModelIdentifier;
-- (NSURL *)performanceTrackingBaseURLFromConfig;
+- (NSURL *)baseURLFromConfig;
 
 @end
 
@@ -34,9 +34,13 @@ NSString *const RPTSDKVersion = @RPT_EXPAND_AND_QUOTE(RPT_SDK_VERSION);
 
         _relayAppId = [bundle objectForInfoDictionaryKey:@"RPTRelayAppID"];
 
-        _performanceTrackingBaseURL = [self performanceTrackingBaseURLFromConfig];
-        NSString *bundleKey = [bundle objectForInfoDictionaryKey:@"RPTSubscriptionKey"];
-        _performanceTrackingSubscriptionKey = bundleKey.length ? [@"ras-" stringByAppendingString:bundleKey] : nil;
+        _baseURL = [self baseURLFromConfig];
+
+        NSString *bundleKey = [bundle objectForInfoDictionaryKey:@"RASSubscriptionKey"] ?: [bundle objectForInfoDictionaryKey:@"RPTSubscriptionKey"];
+        _subscriptionKey = bundleKey.length ? [@"ras-" stringByAppendingString:bundleKey] : nil;
+
+        NSNumber *bundleMaximumMetricDuration = [bundle objectForInfoDictionaryKey:@"RPTMaximumMetricDurationSeconds"];
+        _maximumMetricDurationSeconds = bundleMaximumMetricDuration.doubleValue;
 
         _deviceCountry = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
     }
@@ -56,7 +60,7 @@ NSString *const RPTSDKVersion = @RPT_EXPAND_AND_QUOTE(RPT_SDK_VERSION);
     return [NSString stringWithUTF8String:systemInfo.machine];
 }
 
-- (NSURL *)performanceTrackingBaseURLFromConfig {
+- (NSURL *)baseURLFromConfig {
     NSBundle *bundle = NSBundle.mainBundle;
     NSURL *candidateURL = [NSURL URLWithString:(NSString *)[bundle objectForInfoDictionaryKey:@"RPTConfigAPIEndpoint"]];
 

--- a/RPerformanceTracking/Private/_RPTEventWriter.m
+++ b/RPerformanceTracking/Private/_RPTEventWriter.m
@@ -260,7 +260,7 @@ NSString *_RPTJSONFormatWithFloatValue(NSString *key, float value) {
 
     NSURLResponse *response = nil;
     NSError *error = nil;
-    
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [NSURLConnection sendSynchronousRequest:request

--- a/RPerformanceTracking/Private/_RPTMetric.m
+++ b/RPerformanceTracking/Private/_RPTMetric.m
@@ -1,4 +1,5 @@
 #import "_RPTMetric.h"
+#import "_RPTEnvironment.h"
 
 const NSTimeInterval _RPT_METRIC_MAXTIME = 10.0;
 
@@ -37,7 +38,8 @@ const NSTimeInterval _RPT_METRIC_MAXTIME = 10.0;
 }
 
 + (NSTimeInterval)maxDurationInSecs {
-    return _RPT_METRIC_MAXTIME;
+    _RPTEnvironment *env = _RPTEnvironment.new;
+    return env.maximumMetricDurationSeconds > 0 ? env.maximumMetricDurationSeconds : _RPT_METRIC_MAXTIME;
 }
 
 @end

--- a/Tests/MetricTests.m
+++ b/Tests/MetricTests.m
@@ -5,9 +5,27 @@ SPEC_BEGIN(RPTMetricTests)
 
 describe(@"RPTMetric", ^{
     describe(@"maxDurationInSecs", ^{
-        it(@"should return value 10.0", ^{
+        it(@"should return default value 10.0 when the RPTMaximumMetricDurationSeconds key is missing from the plist", ^{
+            [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:nil withArguments:@"RPTMaximumMetricDurationSeconds"];
+
             NSTimeInterval max = [_RPTMetric maxDurationInSecs];
             
+            [[theValue(max) should] equal:theValue(10.0)];
+        });
+
+        it(@"should return value equal to the RPTMaximumMetricDurationSeconds plist key", ^{
+            [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:@(20.5) withArguments:@"RPTMaximumMetricDurationSeconds"];
+
+            NSTimeInterval max = [_RPTMetric maxDurationInSecs];
+
+            [[theValue(max) should] equal:theValue(20.5)];
+        });
+
+        it(@"should return default value 10.0 when the RPTMaximumMetricDurationSeconds plist key is set to 0", ^{
+            [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:@(0) withArguments:@"RPTMaximumMetricDurationSeconds"];
+
+            NSTimeInterval max = [_RPTMetric maxDurationInSecs];
+
             [[theValue(max) should] equal:theValue(10.0)];
         });
     });

--- a/Tests/RPTEnvironmentTests.m
+++ b/Tests/RPTEnvironmentTests.m
@@ -60,7 +60,7 @@ describe(@"RPTEnvironment", ^{
                 
                 _RPTEnvironment* env = [_RPTEnvironment new];
                 
-                [[env.performanceTrackingBaseURL should] equal:[NSURL URLWithString:@"http://example.com"]];
+                [[env.baseURL should] equal:[NSURL URLWithString:@"http://example.com"]];
             });
             
             it(@"should set performance tracking base URL as nil if base URL is not available in info.plist", ^{
@@ -68,7 +68,7 @@ describe(@"RPTEnvironment", ^{
                 
                 _RPTEnvironment* env = [_RPTEnvironment new];
                 
-                [[env.performanceTrackingBaseURL should] beNil];
+                [[env.baseURL should] beNil];
             });
             
             it(@"should set performance tracking base URL as nil if base URL in info.plist is not a valid URL", ^{
@@ -76,7 +76,7 @@ describe(@"RPTEnvironment", ^{
                 
                 _RPTEnvironment* env = [_RPTEnvironment new];
                 
-                [[env.performanceTrackingBaseURL should] beNil];
+                [[env.baseURL should] beNil];
             });
             
             it(@"should set performance tracking base URL as nil if base URL in info.plist is an empty string", ^{
@@ -84,27 +84,55 @@ describe(@"RPTEnvironment", ^{
                 
                 _RPTEnvironment* env = [_RPTEnvironment new];
                 
-                [[env.performanceTrackingBaseURL should] beNil];
+                [[env.baseURL should] beNil];
+            });
+        });
+
+        describe(@"performanceTrackingSubscriptionKey", ^{
+            it(@"should set subscription key to info.plist sub key with a ras- prefix", ^{
+                [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:@"perftrack_subscription_key" withArguments:@"RPTSubscriptionKey"];
+
+                _RPTEnvironment* env = [_RPTEnvironment new];
+
+                [[env.subscriptionKey should] equal:@"ras-perftrack_subscription_key"];
+            });
+
+            it(@"subscription key should be nil when info.plist doesn't contain sub key", ^{
+                [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:nil];
+
+                _RPTEnvironment* env = [_RPTEnvironment new];
+
+                [[env.subscriptionKey should] beNil];
+            });
+        });
+
+        describe(@"maximumMetricDurationSeconds", ^{
+            it(@"should set max duration to info.plist RPTMaximumMetricDurationSeconds integer value", ^{
+                [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:@(20) withArguments:@"RPTMaximumMetricDurationSeconds"];
+
+                _RPTEnvironment* env = [_RPTEnvironment new];
+
+                [[theValue(env.maximumMetricDurationSeconds) should] equal:theValue(20.0)];
+            });
+
+            it(@"should set max duration to info.plist RPTMaximumMetricDurationSeconds double value", ^{
+                [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:@(20.5) withArguments:@"RPTMaximumMetricDurationSeconds"];
+
+                _RPTEnvironment* env = [_RPTEnvironment new];
+
+                [[theValue(env.maximumMetricDurationSeconds) should] equal:theValue(20.5)];
+            });
+
+            it(@"should set max duration to 0 when RPTMaximumMetricDurationSeconds is not in info.plist", ^{
+                [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:nil withArguments:@"RPTMaximumMetricDurationSeconds"];
+
+                _RPTEnvironment* env = [_RPTEnvironment new];
+
+                [[theValue(env.maximumMetricDurationSeconds) should] equal:theValue(0)];
             });
         });
         
-        it(@"should set performance tracking subscription key as performance tracking subscription key from info.plist with a ras- prefix", ^{
-            [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:@"perftrack_subscription_key" withArguments:@"RPTSubscriptionKey"];
-            
-            _RPTEnvironment* env = [_RPTEnvironment new];
-            
-            [[env.performanceTrackingSubscriptionKey should] equal:@"ras-perftrack_subscription_key"];
-        });
-
-        it(@"performance tracking subscription key should be nil when info.plist doesn't contain subscription key", ^{
-            [[NSBundle mainBundle] stub:@selector(objectForInfoDictionaryKey:) andReturn:nil];
-
-            _RPTEnvironment* env = [_RPTEnvironment new];
-
-            [[env.performanceTrackingSubscriptionKey should] beNil];
-        });
-        
-        it(@"should set device country as coutry reported by current locale", ^{
+        it(@"should set device country as country reported by current locale", ^{
             [[NSLocale currentLocale] stub:@selector(objectForKey:) andReturn:@"country_code" withArguments:NSLocaleCountryCode];
             
             _RPTEnvironment* env = [_RPTEnvironment new];

--- a/Tests/TestUtils.m
+++ b/Tests/TestUtils.m
@@ -79,8 +79,8 @@ _RPTEnvironment* mkEnvironmentStub(NSDictionary* params) {
         @"modelIdentifier": @"default_iOS_device",
         @"osVersion": @"0.0.1",
         @"relayAppId": @"default_relay_app_id",
-        @"performanceTrackingBaseURL": [NSURL URLWithString:@"http://default_perftrack_base_url"],
-        @"performanceTrackingSubscriptionKey": @"default_performance_tracking_subscription_key",
+        @"baseURL": [NSURL URLWithString:@"http://default_base_url"],
+        @"subscriptionKey": @"default_subscription_key",
         @"deviceCountry": @"default_device_country"
     });
     


### PR DESCRIPTION
- Allow the maximum metric duration to be set by a plist key RPTMaximumMetricDurationSeconds 
- Add support for `RASSubscriptionKey` in plist while maintaining backwards compatibility with previous key name
- Remove unnecessary `performanceTracking` prefix from property names

Implements SDKCF-886