### PR TITLE
Fix/single metric clears all 1611

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 xcode_workspace: RPerformanceTracking.xcworkspace
 xcode_scheme: Tests
-osx_image: xcode10.1
+osx_image: xcode11
 
 before_install:
 - gem update fastlane cocoapods --no-document

--- a/RPerformanceTracking/Private/_RPTEventWriter.h
+++ b/RPerformanceTracking/Private/_RPTEventWriter.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)writeWithMetric:(_RPTMetric *)metric;
 - (void)writeWithMeasurement:(_RPTMeasurement *)measurement metricIdentifier:(nullable NSString *)metricIdentifier;
 - (void)end;
+- (BOOL)writingInProgress;
 
 @end
 

--- a/RPerformanceTracking/Private/_RPTEventWriter.m
+++ b/RPerformanceTracking/Private/_RPTEventWriter.m
@@ -63,6 +63,10 @@ NSString *_RPTJSONFormatWithFloatValue(NSString *key, float value) {
     return self;
 }
 
+- (BOOL)writingInProgress {
+    return _measurementCount > 0;
+}
+
 - (void)begin {
     UIDevice *device = [UIDevice currentDevice];
     __block NSString *carrierName;

--- a/RPerformanceTracking/Private/_RPTSender.m
+++ b/RPerformanceTracking/Private/_RPTSender.m
@@ -196,7 +196,7 @@ static const NSTimeInterval SLEEP_MAX_INTERVAL = 1800;         // 30 minutes
         return;
     }
 
-    if (!_sentCount) {
+    if (![_eventWriter writingInProgress]) {
         [_eventWriter begin];
     }
 


### PR DESCRIPTION
fix: only call eventWriter#begin when there is no event writing in progress
    
- sendSingleMetric was being called in between the execution of eventWriter#writeMeasurement and eventWriter#end. sendSingleMetric calls writeMetric which in turn calls eventWriter#begin which clears the event string buffer. This is why events were missing from the payload and only the metric was getting sent.
- Instead of using the sentCount to decide whether to call begin it is better to use the eventWriter's writing state.
- Update travis Xcode version
- Fixes SDKCF-1611
